### PR TITLE
Test panel: add support for accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@
 server
 
 # wasm
-*/target
+**/target
 **/www
 

--- a/client/src/components/Panels/Side/Right/Test/FetchableAccount.tsx
+++ b/client/src/components/Panels/Side/Right/Test/FetchableAccount.tsx
@@ -1,0 +1,129 @@
+import { BN, Idl } from "@project-serum/anchor";
+import { useConnection } from "@solana/wallet-adapter-react";
+import { PublicKey } from "@solana/web3.js";
+import { FC, useEffect, useState } from "react";
+import styled, { css } from "styled-components";
+import { PgAccount } from "../../../../../utils/pg/account";
+import Button from "../../../../Button";
+import Foldable from "../../../../Foldable";
+import Input, { defaultInputProps } from "../../../../Input";
+import { useCurrentWallet } from "../../../Wallet";
+import InputLabel from "./InputLabel";
+
+interface FetchableAccountProps extends FetchableAccountInsideProps {
+  index: number;
+}
+
+const FetchableAccount: FC<FetchableAccountProps> = ({ accountName, idl, index }) => (
+  <FetchableAccountWrapper index={index}>
+    <Foldable ClickEl={<AccountName>{accountName}</AccountName>}>
+      <FetchableAccountInside idl={idl} accountName={accountName} />
+    </Foldable>
+  </FetchableAccountWrapper>
+)
+
+interface FetchableAccountInsideProps {
+  accountName: string;
+  idl: Idl;
+}
+
+const FetchableAccountInside = ({ accountName, idl }: FetchableAccountInsideProps) => {
+  const { connection: conn } = useConnection();
+  const { currentWallet } = useCurrentWallet();
+
+  const [enteredAddress, setEnteredAddress] = useState("");
+  const [fetchedData, setFetchedData] = useState<any>();
+
+  useEffect(() => {
+    // The default BN.toJSON is a hex string, but we want a readable string
+    // Temporarily change it to use a plain toString while this component is mounted
+    const oldBNPrototypeToJSON = BN.prototype.toJSON;
+    BN.prototype.toJSON = function (this: BN) {
+      return this.toString();
+    }
+
+    // Change the toJSON prototype back on unmount
+    return () => { BN.prototype.toJSON = oldBNPrototypeToJSON }
+  }, [])
+
+  const fetchAll = async () => {
+    if (!currentWallet) return;
+    setFetchedData(null);
+    const accountData = await PgAccount.fetchAll(accountName, idl, conn, currentWallet);
+    console.log({ accountData });
+    setFetchedData(accountData);
+  }
+
+  const fetchEntered = async () => {
+    if (!currentWallet) return;
+    setFetchedData(null);
+    const accountData = await PgAccount.fetchOne(accountName, new PublicKey(enteredAddress), idl, conn, currentWallet);
+    console.log({ accountData: accountData.data.toString() });
+    setFetchedData(accountData);
+  }
+
+  return (
+    <>
+      <InputWrapper>
+        <InputLabel label="address" type="publicKey" />
+        <Input type="text" value={enteredAddress} onChange={e => setEnteredAddress(e.target.value)} {...defaultInputProps} />
+      </InputWrapper>
+
+      <ButtonsWrapper>
+        <Button onClick={fetchEntered} disabled={!enteredAddress} kind="outline" fullWidth={false} size="small">Fetch Entered</Button>
+        <Button onClick={fetchAll} kind="outline" fullWidth={false} size="small">Fetch All</Button>
+      </ButtonsWrapper>
+
+      {fetchedData && (
+        <ResultWrapper>
+          <Foldable ClickEl={<span>Result</span>} open>
+            <Result>
+              {JSON.stringify(fetchedData, null, 2)}
+            </Result>
+          </Foldable>
+        </ResultWrapper>
+      )}
+    </>
+  )
+}
+
+interface FetchableAccountWrapperProps {
+  index: number;
+}
+
+const FetchableAccountWrapper = styled.div<FetchableAccountWrapperProps>`
+  ${({ theme, index }) => css`
+    padding: 1rem;
+    border-top: 1px solid ${theme.colors.default.borderColor};
+    background-color: ${index % 2 === 0 && theme.colors.right?.otherBg};
+
+    &:last-child {
+      border-bottom: 1px solid ${theme.colors.default.borderColor};
+    }
+  `}
+`;
+
+const AccountName = styled.span`
+  font-weight: bold;
+`;
+
+const InputWrapper = styled.div`
+  margin: 0.5rem 0;
+`;
+
+const ButtonsWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+`;
+
+const ResultWrapper = styled.div`
+    margin: 0.5rem 0;
+`;
+
+const Result = styled.pre`
+    user-select: text;
+    font-family: monospace;
+`
+
+export default FetchableAccount;

--- a/client/src/components/Panels/Side/Right/Test/Test.tsx
+++ b/client/src/components/Panels/Side/Right/Test/Test.tsx
@@ -8,6 +8,7 @@ import { PgProgramInfo } from "../../../../../utils/pg";
 import { Wormhole } from "../../../../Loading";
 import { ConnectionErrorText } from "../../Common";
 import { useIsDeployed } from "../BuildDeploy";
+import FetchableAccount from "./FetchableAccount";
 
 // Webpack 5 doesn't polyfill buffer
 window.Buffer = buffer.Buffer;
@@ -76,9 +77,20 @@ const Test = () => {
             Program:
             <ProgramName>{idl.name}</ProgramName>
           </ProgramNameWrapper>
-          {idl.instructions.map((ixs, i) => (
-            <Function key={i} idl={idl} index={i} ixs={ixs} />
-          ))}
+
+          <ProgramInteractionWrapper>
+            <Subheading>Instructions</Subheading>
+            {idl.instructions.map((ixs, i) => (
+              <Function key={i} idl={idl} index={i} ixs={ixs} />
+            ))}
+          </ProgramInteractionWrapper>
+
+          <ProgramInteractionWrapper>
+            <Subheading>Accounts</Subheading>
+            {idl.accounts?.map((acc, i) => (
+              <FetchableAccount key={i} index={i} accountName={acc.name} idl={idl} />
+            ))}
+          </ProgramInteractionWrapper>
         </ProgramWrapper>
       </Wrapper>
     );
@@ -100,16 +112,26 @@ const InitialWrapper = styled.div`
 
 const ProgramWrapper = styled.div`
   user-select: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 1rem;
 `;
 
 const ProgramNameWrapper = styled.div`
-  padding: 1rem;
+  padding-left: 1rem;
 `;
 
 const ProgramName = styled.span`
   font-weight: bold;
   margin-left: 0.25rem;
 `;
+
+const Subheading = styled.h4`
+  margin: 0.5rem 1rem;
+`
+
+const ProgramInteractionWrapper = styled.div``;
 
 export default Test;
 

--- a/client/src/utils/pg/account.ts
+++ b/client/src/utils/pg/account.ts
@@ -1,0 +1,47 @@
+import { Idl, Program, Provider } from "@project-serum/anchor";
+import { AnchorWallet } from "@solana/wallet-adapter-react";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { PgCommon } from "./common";
+import { PgProgramInfo } from "./program-info";
+import { PgWallet } from "./wallet";
+
+export class PgAccount {
+  private static async getProgram(
+    idl: Idl,
+    conn: Connection,
+    wallet: PgWallet | AnchorWallet
+  ) {
+    const provider = new Provider(conn, wallet, Provider.defaultOptions());
+
+    // Get program pk
+    const programPkResult = PgProgramInfo.getPk();
+    if (programPkResult.err) throw new Error(programPkResult.err);
+    const programPk = programPkResult.programPk!;
+
+    const program = new Program(idl, programPk, provider);
+    return program;
+  }
+
+  static async fetchAll(
+    accountName: string,
+    idl: Idl,
+    conn: Connection,
+    wallet: PgWallet | AnchorWallet
+  ) {
+    const program = await this.getProgram(idl, conn, wallet)
+    const allAccountData = await program.account[PgCommon.camelize(accountName)].all();
+    return allAccountData;
+  }
+
+  static async fetchOne(
+    accountName: string,
+    address: PublicKey,
+    idl: Idl,
+    conn: Connection,
+    wallet: PgWallet | AnchorWallet
+  ) {
+    const program = await this.getProgram(idl, conn, wallet)
+    const accountData = await program.account[PgCommon.camelize(accountName)].fetch(address);
+    return accountData;
+  }
+}

--- a/client/src/utils/pg/common.ts
+++ b/client/src/utils/pg/common.ts
@@ -170,4 +170,12 @@ export class PgCommon {
 
     document.dispatchEvent(customEvent);
   }
+
+  // From https://stackoverflow.com/a/2970667/1375972
+  static camelize(str: string) {
+    return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function (match, index) {
+      if (+match === 0) return ""; // or if (/\s+/.test(match)) for white spaces
+      return index === 0 ? match.toLowerCase() : match.toUpperCase();
+    });
+  }
 }


### PR DESCRIPTION
This PR updates the Test panel to add support for displaying the accounts parsed from the IDL, and for each of them fetching all accounts or one account by its public key.

This allows inspecting the results of an instruction immediately and without leaving the Test UI. 

Demo: 
https://user-images.githubusercontent.com/1711350/179417905-1f1794cf-a95b-4e0c-880e-5ffb1a201c2c.mov

Implementation details:

- I've tried to keep the styling consistent with the existing instructions. I'm not experienced with styled components though so please let me know if I did anything wrong! 
- The new component used to display a row of `Account` data (in a Foldable, similar to instructions) is `FetchableAccount`
- There's a bit of a hack to override the `toJson` method on the `BN` object. By default it's a hex string (https://github.com/indutny/bn.js/#utilities) which isn't very helpful when it's a public key. I tried implementing a replacer in `JSON.stringify` but that didn't work, the default toJson has already been called on it before it's passed to the replacer. So I override the prototype to use `toString` instead, which gives us the public keys we expect.
- Similarly to with instructions, the actual account fetching is implemented in static functions on a new `PgAccount` class.
- The account names need to be camel-case when used in `program.account.newAccount.[...]`, whereas they're in pascal case in the IDL.

<img width="367" alt="Screenshot 2022-07-17 at 18 25 35" src="https://user-images.githubusercontent.com/1711350/179418241-3629308a-d7fa-47a6-a377-4dc1eb159e47.png">

Closes #36 