### PR TITLE
Account fetch: add input validation + error handling

### DIFF
--- a/client/src/components/Panels/Side/Right/Test/FetchableAccount.tsx
+++ b/client/src/components/Panels/Side/Right/Test/FetchableAccount.tsx
@@ -1,7 +1,7 @@
 import { BN, Idl } from "@project-serum/anchor";
 import { useConnection } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
-import { FC, useEffect, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import styled, { css } from "styled-components";
 import { PgAccount } from "../../../../../utils/pg/account";
 import Button from "../../../../Button";
@@ -32,6 +32,7 @@ const FetchableAccountInside = ({ accountName, idl }: FetchableAccountInsideProp
   const { currentWallet } = useCurrentWallet();
 
   const [enteredAddress, setEnteredAddress] = useState("");
+  const [enteredAddressError, setEnteredAddressError] = useState(false);
   const [fetchedData, setFetchedData] = useState<any>();
 
   useEffect(() => {
@@ -62,16 +63,52 @@ const FetchableAccountInside = ({ accountName, idl }: FetchableAccountInsideProp
     setFetchedData(accountData);
   }
 
+  const enteredAddressChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const address = e.target.value;
+    if (address) {
+      try {
+        new PublicKey(address);
+        setEnteredAddressError(false);
+      } catch {
+        setEnteredAddressError(true);
+      }
+    }
+
+    setEnteredAddress(address);
+  }
+
   return (
     <>
       <InputWrapper>
         <InputLabel label="address" type="publicKey" />
-        <Input type="text" value={enteredAddress} onChange={e => setEnteredAddress(e.target.value)} {...defaultInputProps} />
+        <Input
+          type="text"
+          className={enteredAddressError ? 'error' : ''}
+          value={enteredAddress}
+          onChange={enteredAddressChanged}
+          {...defaultInputProps}
+        />
       </InputWrapper>
 
       <ButtonsWrapper>
-        <Button onClick={fetchEntered} disabled={!enteredAddress} kind="outline" fullWidth={false} size="small">Fetch Entered</Button>
-        <Button onClick={fetchAll} kind="outline" fullWidth={false} size="small">Fetch All</Button>
+        <Button
+          onClick={fetchEntered}
+          disabled={!enteredAddress || enteredAddressError || !currentWallet}
+          kind="outline"
+          fullWidth={false}
+          size="small"
+        >
+          Fetch Entered
+        </Button>
+        <Button
+          onClick={fetchAll}
+          disabled={!currentWallet}
+          kind="outline"
+          fullWidth={false}
+          size="small"
+        >
+          Fetch All
+        </Button>
       </ButtonsWrapper>
 
       {fetchedData && (


### PR DESCRIPTION
This PR adds some missing validation/error handling mentioned in #40 

- If the entered address is not a valid public key, input shows an error and fetch entered button is disabled:
<img width="316" alt="Screenshot 2022-07-18 at 19 27 46" src="https://user-images.githubusercontent.com/1711350/179578353-4165fd1b-bcce-4e4f-adfa-457729ce9b94.png">

- If the playground wallet is not connected, both buttons are disabled:
<img width="363" alt="Screenshot 2022-07-18 at 19 29 20" src="https://user-images.githubusercontent.com/1711350/179578560-89e5a457-eac1-4953-8b6a-82d6b8373b5d.png">

- RPC errors (such as an incorrect address being entered) are displayed inline:
<img width="316" alt="Screenshot 2022-07-18 at 19 30 45" src="https://user-images.githubusercontent.com/1711350/179578815-e5487c13-4b1c-46f7-b5ee-d0806aed13be.png">

Closes #40 