### PR TITLE
Pass program keypair for generated program id to build API

### DIFF
--- a/client/src/utils/pg/build.ts
+++ b/client/src/utils/pg/build.ts
@@ -24,6 +24,7 @@ export class PgBuild {
       body: JSON.stringify({
         files,
         uuid: programInfo.uuid,
+        kp: programInfo.kp,
       }),
     });
 


### PR DESCRIPTION
Running the latest code locally I was getting an error "The declared program id does not match the actual program id." after a fresh build-deploy-call instruction.

I think the reason is that the client is generating a program ID, but not passing the keypair for it to the server. The server then responds with a `kp` field that doesn't match the program ID on the client.

This PR updates the build API call to pass `kp` to the server, which results in the server responding with the same `kp` and fixes the issue. 