### PR TITLE
Add keypair to the wallet interface so it can be used in client code

### DIFF
--- a/client/src/components/Panels/Main/Editor/Monaco/declarations/pg.raw.d.ts
+++ b/client/src/components/Panels/Main/Editor/Monaco/declarations/pg.raw.d.ts
@@ -2,6 +2,7 @@ declare module "solana-playground" {
   import * as web3 from "@solana/web3.js";
   interface PgWallet {
     publicKey: web3.PublicKey;
+    keypair: web3.Keypair;
     signTransaction: (tx: web3.Transaction) => Promise<web3.Transaction>;
     signAllTransactions: (
       txs: web3.Transaction[]

--- a/client/src/utils/pg/wallet.ts
+++ b/client/src/utils/pg/wallet.ts
@@ -16,7 +16,7 @@ const DEFAULT_LS_WALLET: LsWallet = {
 };
 
 export class PgWallet {
-  private _kp: Keypair;
+  keypair: Keypair;
   // Public key will always be set
   publicKey: PublicKey;
   // Connected can change
@@ -29,21 +29,21 @@ export class PgWallet {
       PgWallet.update(DEFAULT_LS_WALLET);
     }
 
-    this._kp = Keypair.fromSecretKey(new Uint8Array(lsWallet.sk));
-    this.publicKey = this._kp.publicKey;
+    this.keypair = Keypair.fromSecretKey(new Uint8Array(lsWallet.sk));
+    this.publicKey = this.keypair.publicKey;
     this.connected = lsWallet.connected;
   }
 
   // For compatibility with AnchorWallet
   async signTransaction(tx: Transaction) {
-    tx.partialSign(this._kp);
+    tx.partialSign(this.keypair);
     return tx;
   }
 
   // For compatibility with AnchorWallet
   async signAllTransactions(txs: Transaction[]) {
     for (const tx of txs) {
-      tx.partialSign(this._kp);
+      tx.partialSign(this.keypair);
     }
 
     return txs;


### PR DESCRIPTION
This PR slightly modifies the `PgWallet` interface to make `keypair` accessible.

This allows writing client code like:
```ts
const transactionSignature = await web3.sendAndConfirmTransaction(
  pg.connection,
  transaction,
  [pg.wallet.keypair]
);
```
This is a lot simpler than using `pg.wallet.signTransaction` and then sending it as a raw transaction. I think that's currently how you'd need to send a transaction?

Note that this doesn't have any security implications, client code can already run `pg.wallet._kp` to get at the currently private field.

If we do need to hide the keypair for security then maybe we could add `_kp` to the blacklisted words? But I do think it's a lot nicer to be able to access the keypair in client code if possible!