### PR TITLE
Blacklist eval and Function in client code

### DIFF
--- a/client/src/utils/pg/client/client.ts
+++ b/client/src/utils/pg/client/client.ts
@@ -348,4 +348,6 @@ const _BLACKLISTED_WORDS = [
   "location",
   "top",
   "chrome",
+  "eval",
+  "Function",
 ];


### PR DESCRIPTION
Stops you doing evil things like `console.log(eval("global" + "This" + ".pg"));`

Since both of these execute code given as a string, they allow bypassing the blacklist by concatenation