### PR TITLE
Use the same import regex when removing imports

### DIFF
--- a/client/src/utils/pg/client/client.ts
+++ b/client/src/utils/pg/client/client.ts
@@ -158,7 +158,7 @@ export class PgClient {
       // Remove import statements
       // Need to do this after we setup all the imports because of internal
       // cursor index state the regex.exec has.
-      code = code.replace(/import\s+[*|{](.?\n?)+["|'].+["|']/gm, "");
+      code = code.replace(importRegex, "");
 
       // Playground utils namespace
       const pg: Pg = { connection };


### PR DESCRIPTION
This fixes a bug where code after the import was also being removed