### PR TITLE
Add events to the Test page, display recorded events from the program

### DIFF
--- a/client/src/components/Panels/Side/Right/Test/CodeResult.tsx
+++ b/client/src/components/Panels/Side/Right/Test/CodeResult.tsx
@@ -1,0 +1,44 @@
+import styled, { css } from "styled-components";
+
+interface CodeResultProps {
+  index: number;
+}
+
+export const CodeResult = styled.pre<CodeResultProps>`
+  ${({ theme, index }) => css`
+    margin-top: 0.25rem;
+    user-select: text;
+    width: 100%;
+    overflow-x: auto;
+    padding: 0.75rem 0.5rem;
+    background-color: ${index % 2 === 1
+      ? theme.colors.right?.otherBg
+      : theme.colors.right?.bg};
+    border-radius: ${theme.borderRadius};
+
+    /* Scrollbar */
+    /* Chromium */
+    &::-webkit-scrollbar {
+      height: 0.5rem;
+    }
+
+    &::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border: 0.25rem solid transparent;
+      border-radius: ${theme.borderRadius};
+      background-color: ${theme.scrollbar?.thumb.color};
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background-color: ${theme.scrollbar?.thumb.hoverColor};
+    }
+
+    /* Firefox */
+    & * {
+      scrollbar-color: ${theme.scrollbar?.thumb.color};
+    }
+  `}
+`;

--- a/client/src/components/Panels/Side/Right/Test/FetchableAccount.tsx
+++ b/client/src/components/Panels/Side/Right/Test/FetchableAccount.tsx
@@ -1,5 +1,5 @@
-import { ChangeEvent, FC, useEffect, useState } from "react";
-import { BN, Idl } from "@project-serum/anchor";
+import { ChangeEvent, FC, useState } from "react";
+import { Idl } from "@project-serum/anchor";
 import { useConnection } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
 import styled, { css } from "styled-components";
@@ -12,6 +12,7 @@ import { ClassName } from "../../../../../constants";
 import { PgAccount, PgCommon } from "../../../../../utils/pg";
 import { SpinnerWithBg } from "../../../../Loading";
 import { useCurrentWallet } from "../../../Wallet";
+import { CodeResult } from "./CodeResult";
 
 interface FetchableAccountProps {
   accountName: string;
@@ -50,20 +51,6 @@ const FetchableAccountInside: FC<FetchableAccountProps> = ({
   const [fetchOneLoading, setFetchOneLoading] = useState(false);
   const [fetchAllLoading, setFetchAllLoading] = useState(false);
   const [resultOpen, setResultOpen] = useState(false);
-
-  useEffect(() => {
-    // The default BN.toJSON is a hex string, but we want a readable string
-    // Temporarily change it to use a plain toString while this component is mounted
-    const oldBNPrototypeToJSON = BN.prototype.toJSON;
-    BN.prototype.toJSON = function (this: BN) {
-      return this.toString();
-    };
-
-    // Change the toJSON prototype back on unmount
-    return () => {
-      BN.prototype.toJSON = oldBNPrototypeToJSON;
-    };
-  }, []);
 
   const handleAddressChange = (e: ChangeEvent<HTMLInputElement>) => {
     const address = e.target.value;
@@ -177,13 +164,13 @@ const FetchableAccountInside: FC<FetchableAccountProps> = ({
             setOpen={setResultOpen}
           >
             <SpinnerWithBg loading={fetchOneLoading || fetchAllLoading}>
-              <Result index={index}>
+              <CodeResult index={index}>
                 {fetchError ? (
                   <ErrorWrapper>{fetchError}</ErrorWrapper>
                 ) : (
                   JSON.stringify(fetchedData, null, 2)
                 )}
-              </Result>
+              </CodeResult>
             </SpinnerWithBg>
           </Foldable>
         </ResultWrapper>
@@ -225,45 +212,6 @@ const ButtonsWrapper = styled.div`
 const ResultWrapper = styled.div`
   margin-top: 1rem;
   width: 100%;
-`;
-
-const Result = styled.pre<IndexProp>`
-  ${({ theme, index }) => css`
-    margin-top: 0.25rem;
-    user-select: text;
-    width: 100%;
-    overflow-x: auto;
-    padding: 0.75rem 0.5rem;
-    background-color: ${index % 2 === 1
-      ? theme.colors.right?.otherBg
-      : theme.colors.right?.bg};
-    border-radius: ${theme.borderRadius};
-
-    /* Scrollbar */
-    /* Chromium */
-    &::-webkit-scrollbar {
-      height: 0.5rem;
-    }
-
-    &::-webkit-scrollbar-track {
-      background-color: transparent;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      border: 0.25rem solid transparent;
-      border-radius: ${theme.borderRadius};
-      background-color: ${theme.scrollbar?.thumb.color};
-    }
-
-    &::-webkit-scrollbar-thumb:hover {
-      background-color: ${theme.scrollbar?.thumb.hoverColor};
-    }
-
-    /* Firefox */
-    & * {
-      scrollbar-color: ${theme.scrollbar?.thumb.color};
-    }
-  `}
 `;
 
 const ErrorWrapper = styled.div`

--- a/client/src/components/Panels/Side/Right/Test/ListenableEvent.tsx
+++ b/client/src/components/Panels/Side/Right/Test/ListenableEvent.tsx
@@ -1,0 +1,67 @@
+import { Idl, Program } from "@project-serum/anchor";
+import { FC, useEffect, useState } from "react";
+import styled, { css } from "styled-components";
+import Foldable from "../../../../Foldable";
+import { CodeResult } from "./CodeResult";
+
+interface EventProps {
+  program: Program<Idl> | null;
+  eventName: string;
+  index: number;
+}
+
+const ListenableEvent: FC<EventProps> = ({ program, eventName, index }) => {
+  const [receivedEvents, setReceivedEvents] = useState<object[]>([]);
+
+  useEffect(() => {
+    if (!program) return;
+
+    const listener = program.addEventListener(
+      eventName,
+      (emittedEvent, _slot) => {
+        setReceivedEvents((eventsSoFar) => [...eventsSoFar, emittedEvent]);
+      }
+    );
+
+    return () => {
+      program.removeEventListener(listener);
+    };
+  }, [eventName, program]);
+
+  return (
+    <EventWrapper index={index}>
+      <Foldable
+        ClickEl={
+          <EventName>{`${eventName} (${receivedEvents.length})`}</EventName>
+        }
+      >
+        <CodeResult index={index}>
+          {receivedEvents.map((e) => JSON.stringify(e, null, 2)).join("\n")}
+        </CodeResult>
+      </Foldable>
+    </EventWrapper>
+  );
+};
+
+interface IndexProp {
+  index: number;
+}
+
+const EventWrapper = styled.div<IndexProp>`
+  ${({ theme, index }) => css`
+    padding: 1rem;
+    border-top: 1px solid ${theme.colors.default.borderColor};
+    background-color: ${index % 2 === 0 && theme.colors.right?.otherBg};
+
+    &:last-child {
+      border-bottom: 1px solid ${theme.colors.default.borderColor};
+    }
+  `}
+`;
+
+const EventName = styled.span`
+  font-weight: bold;
+  margin: 0.5rem 0;
+`;
+
+export default ListenableEvent;

--- a/client/src/hooks/useBigNumberJson.tsx
+++ b/client/src/hooks/useBigNumberJson.tsx
@@ -1,0 +1,18 @@
+import BN from "bn.js";
+import { useEffect } from "react";
+
+export const useBigNumberJson = () => {
+  useEffect(() => {
+    // The default BN.toJSON is a hex string, but we want a readable string
+    // Temporarily change it to use a plain toString while this component is mounted
+    const oldBNPrototypeToJSON = BN.prototype.toJSON;
+    BN.prototype.toJSON = function (this: BN) {
+      return this.toString();
+    };
+
+    // Change the toJSON prototype back on unmount
+    return () => {
+      BN.prototype.toJSON = oldBNPrototypeToJSON;
+    };
+  }, []);
+};


### PR DESCRIPTION
This PR adds an events section to the test page. It lists the events in the anchor IDL, listens for instances of those events and displays them in a foldable section.

https://user-images.githubusercontent.com/1711350/201411651-efe85006-fa13-48b7-b63a-1e648d1ce605.mov

This means that you can verify/experiment with the events emitted by your program while testing it in playground.

I've refactored out some stuff that's shared with the accounts section: the styled code block, and the hacky replacement of `BN.toJson` to make large numbers display nicely.

Note that the event listeners are only active when the test page is open, they're cleaned up on navigation away and the recorded events are reset too. 

Closes #73 