### PR TITLE
Vscode: Fix seahorse project generate

### DIFF
--- a/vscode/src/commands/create/anchor.ts
+++ b/vscode/src/commands/create/anchor.ts
@@ -9,6 +9,8 @@ import {
   processCreate,
   processInstallNodeModules,
 } from "./common";
+import { PgFs } from "../../utils";
+import { Uri } from "vscode"
 
 const ANCHOR_VERSION = "0.25.0";
 
@@ -233,5 +235,8 @@ codegen-units = 1
     createdNewFolder,
   });
 
-  return { name };
+  const baseUri = await PgFs.getBaseUri();
+  const projectUri = createdNewFolder ? Uri.joinPath(baseUri, name) : baseUri;
+
+  return { name, projectUri };
 };

--- a/vscode/src/commands/create/seahorse.ts
+++ b/vscode/src/commands/create/seahorse.ts
@@ -1,48 +1,46 @@
 import * as path from "path";
 
 import { PATHS } from "../../constants";
+import { Files, PgFs } from "../../utils";
 import { processCreateAnchor } from "./anchor";
-import { processCreate } from "./common";
 
 export const processCreateSeahorse = async () => {
   // Create Anchor
-  const { name } = await processCreateAnchor();
+  const { name, projectUri } = await processCreateAnchor();
 
-  // Create Seahorse
-  await processCreate({
-    name,
-    files: [
-      // Program <name>.py
-      [
-        path.join(PATHS.DIRS.PROGRAMS_PY, `${name}.py`),
-        `# ${name}
+  const seahorseFiles: Files = [
+    // Program <name>.py
+    [
+      path.join(PATHS.DIRS.PROGRAMS_PY, `${name}.py`),
+      `# ${name}
 # Built with Seahorse v0.2.3
 
 from seahorse.prelude import *
 
 declare_id('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')
 `,
-      ],
-
-      // __init__.py
-      [
-        path.join(
-          PATHS.DIRS.PROGRAMS_PY,
-          PATHS.DIRS.SEAHORSE,
-          PATHS.FILES.INIT_PY
-        ),
-        "",
-      ],
-
-      // prelude.py
-      [
-        path.join(
-          PATHS.DIRS.PROGRAMS_PY,
-          PATHS.DIRS.SEAHORSE,
-          PATHS.FILES.PRELUDE_PY
-        ),
-        require("./seahorse-prelude.py"),
-      ],
     ],
-  });
+
+    // __init__.py
+    [
+      path.join(
+        PATHS.DIRS.PROGRAMS_PY,
+        PATHS.DIRS.SEAHORSE,
+        PATHS.FILES.INIT_PY
+      ),
+      "",
+    ],
+
+    // prelude.py
+    [
+      path.join(
+        PATHS.DIRS.PROGRAMS_PY,
+        PATHS.DIRS.SEAHORSE,
+        PATHS.FILES.PRELUDE_PY
+      ),
+      require("./seahorse-prelude.py"),
+    ],
+  ];
+
+  await PgFs.writeFiles(seahorseFiles, projectUri);
 };


### PR DESCRIPTION
The seahorse project create was erroring on the check for an existing `programs/` directory, because it initializes an Anchor project first. The nesting when there are existing files also isn't appropriate for seahorse.

This PR updates the Seahorse create to write Seahorse files directly after the Anchor create. This avoids the checks and nesting of `processCreate` which aren't suitable when we know there are existing files (the Anchor ones). 