### PR TITLE
Support declare_id in any rust file

### DIFF
--- a/client/src/pages/ide/Panels/Main/MainView/Editor/CodeMirror/CodeMirror.tsx
+++ b/client/src/pages/ide/Panels/Main/MainView/Editor/CodeMirror/CodeMirror.tsx
@@ -315,10 +315,9 @@ const CodeMirror = () => {
     };
 
     // Update in editor
-    const isLibrs = explorer.getCurrentFile()?.path.endsWith("lib.rs");
-    const isPython =
-      !isLibrs && explorer.getCurrentFileLanguage() === Lang.PYTHON;
-    if (!isLibrs && !isPython) return;
+    const isRust = explorer.getCurrentFileLanguage() === Lang.RUST;
+    const isPython = explorer.getCurrentFileLanguage() === Lang.PYTHON;
+    if (!isRust && !isPython) return;
 
     const editorContent = editor.state.doc.toString();
     const indices = getProgramIdStartAndEndIndex(editorContent, isPython);


### PR DESCRIPTION
This PR changes the program ID update logic to support the ID being in any rust file. This will allow building an Anchor project where the id is not declared in lib.rs

- Build files are now prioritised, with lib.rs and id.rs coming first followed by everything else
- The declare_id regex check is done on all build files in priority order, not just lib.rs
- When the regex matches we stop checking future files. In practice this means that if the declare_id is in lib.rs or id.rs then it'll be updated quickly and no other files will be checked. If it's in some other file it'll be detected but will be a bit slower as we check eg lib.rs first
- While I think we only support single file Seahorse projects for now, I've added the same behaviour for Python (though no files are prioritised) so that the same will work easily if we change that 

Test cases:

- Seahorse: https://beta.solpg.io/63f758f067edfe0f001069cc
- Anchor (id in lib.rs): https://beta.solpg.io/63f7595567edfe0f001069d0
- Anchor (id in id.rs): https://beta.solpg.io/63f7591367edfe0f001069cd

Closes #105 