### PR TITLE
Add `simulate_transaction` methods to wasm solana client 

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2861,10 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "solana-playground-utils-wasm"
-version = "0.1.0"
+version = "1.11.0"
 dependencies = [
  "wasm-bindgen",
- "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/wasm/solana-client/src/client.rs
+++ b/wasm/solana-client/src/client.rs
@@ -973,19 +973,19 @@ impl WasmClient {
         &self,
         transaction: &Transaction,
         config: RpcSimulateTransactionConfig,
-    ) -> ClientResult<SimulateTransactionResult> {
+    ) -> ClientResult<SimulateTransactionResponse> {
         let request =
             SimulateTransactionRequest::new_with_config(transaction.to_owned(), config).into();
-        let response = SimulateTransactionResult::from(self.send(request).await?);
+        let response = SimulateTransactionResponse::from(self.send(request).await?);
         Ok(response)
     }
 
     pub async fn simulate_transaction(
         &self,
-        transaction: Transaction,
-    ) -> ClientResult<SimulateTransactionResult> {
+        transaction: &Transaction,
+    ) -> ClientResult<SimulateTransactionResponse> {
         self.simulate_transaction_with_config(
-            &transaction,
+            transaction,
             RpcSimulateTransactionConfig {
                 encoding: Some(UiTransactionEncoding::Base64),
                 replace_recent_blockhash: true,

--- a/wasm/solana-client/src/client.rs
+++ b/wasm/solana-client/src/client.rs
@@ -33,7 +33,8 @@ use crate::{
             RpcBlockProductionConfig, RpcContextConfig, RpcEpochConfig, RpcGetVoteAccountsConfig,
             RpcKeyedAccount, RpcLargestAccountsConfig, RpcLeaderScheduleConfig,
             RpcProgramAccountsConfig, RpcSendTransactionConfig, RpcSignaturesForAddressConfig,
-            RpcSupplyConfig, RpcTokenAccountsFilter, RpcTransactionConfig,
+            RpcSimulateTransactionConfig, RpcSupplyConfig, RpcTokenAccountsFilter,
+            RpcTransactionConfig,
         },
         rpc_filter::TokenAccountsFilter,
         rpc_response::{
@@ -966,5 +967,31 @@ impl WasmClient {
     pub async fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<UiTokenAmount> {
         self.get_token_supply_with_commitment(mint, self.commitment_config())
             .await
+    }
+
+    pub async fn simulate_transaction_with_config(
+        &self,
+        transaction: &Transaction,
+        config: RpcSimulateTransactionConfig,
+    ) -> ClientResult<SimulateTransactionResult> {
+        let request =
+            SimulateTransactionRequest::new_with_config(transaction.to_owned(), config).into();
+        let response = SimulateTransactionResult::from(self.send(request).await?);
+        Ok(response)
+    }
+
+    pub async fn simulate_transaction(
+        &self,
+        transaction: Transaction,
+    ) -> ClientResult<SimulateTransactionResult> {
+        self.simulate_transaction_with_config(
+            &transaction,
+            RpcSimulateTransactionConfig {
+                encoding: Some(UiTransactionEncoding::Base64),
+                replace_recent_blockhash: true,
+                ..Default::default()
+            },
+        )
+        .await
     }
 }

--- a/wasm/solana-client/src/methods/mod.rs
+++ b/wasm/solana-client/src/methods/mod.rs
@@ -94,9 +94,7 @@ pub use {
         GetSignatureStatusesRequest, GetSignatureStatusesResponse, SignatureStatusesValue,
     },
     signatures_for_address::{GetSignaturesForAddressRequest, GetSignaturesForAddressResponse},
-    simulate_transaction::{
-        SimulateTransactionRequest, SimulateTransactionResponse, SimulateTransactionResult,
-    },
+    simulate_transaction::{SimulateTransactionRequest, SimulateTransactionResponse},
     slot::{GetSlotRequest, GetSlotResponse},
     slot_leader::{GetSlotLeaderRequest, GetSlotLeaderResponse},
     slot_leaders::{GetSlotLeadersRequest, GetSlotLeadersResponse},

--- a/wasm/solana-client/src/methods/mod.rs
+++ b/wasm/solana-client/src/methods/mod.rs
@@ -94,7 +94,9 @@ pub use {
         GetSignatureStatusesRequest, GetSignatureStatusesResponse, SignatureStatusesValue,
     },
     signatures_for_address::{GetSignaturesForAddressRequest, GetSignaturesForAddressResponse},
-    simulate_transaction::{SimulateTransactionRequest, SimulateTransactionResponse},
+    simulate_transaction::{
+        SimulateTransactionRequest, SimulateTransactionResponse, SimulateTransactionResult,
+    },
     slot::{GetSlotRequest, GetSlotResponse},
     slot_leader::{GetSlotLeaderRequest, GetSlotLeaderResponse},
     slot_leaders::{GetSlotLeadersRequest, GetSlotLeadersResponse},

--- a/wasm/solana-client/src/methods/simulate_transaction.rs
+++ b/wasm/solana-client/src/methods/simulate_transaction.rs
@@ -1,6 +1,7 @@
-use crate::{utils::rpc_config::RpcSimulateTransactionConfig, ClientRequest, ClientResponse};
 use solana_extra_wasm::{account_decoder::UiAccount, transaction_status::UiTransactionEncoding};
 use solana_sdk::transaction::{Transaction, TransactionError};
+
+use crate::{utils::rpc_config::RpcSimulateTransactionConfig, ClientRequest, ClientResponse};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimulateTransactionRequest {
@@ -50,6 +51,7 @@ impl Into<ClientRequest> for SimulateTransactionRequest {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct SimulateTransactionResponse {
     pub err: Option<TransactionError>,
     pub logs: Option<Vec<String>>,
@@ -59,12 +61,14 @@ pub struct SimulateTransactionResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct UiTransactionReturnData {
     pub program_id: String,
     pub data: (String, UiReturnDataEncoding),
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub enum UiReturnDataEncoding {
     Base64,
 }

--- a/wasm/solana-client/src/utils/rpc_response.rs
+++ b/wasm/solana-client/src/utils/rpc_response.rs
@@ -329,38 +329,6 @@ pub struct RpcVoteAccountInfo {
 
 // #[derive(Serialize, Deserialize, Clone, Debug)]
 // #[serde(rename_all = "camelCase")]
-// pub struct RpcSimulateTransactionResult {
-//     pub err: Option<TransactionError>,
-//     pub logs: Option<Vec<String>>,
-//     pub accounts: Option<Vec<Option<UiAccount>>>,
-//     pub units_consumed: Option<u64>,
-//     pub return_data: Option<RpcTransactionReturnData>,
-// }
-
-// #[derive(Serialize, Deserialize, Clone, Debug)]
-// #[serde(rename_all = "camelCase")]
-// pub struct RpcTransactionReturnData {
-//     pub program_id: String,
-//     pub data: (String, ReturnDataEncoding),
-// }
-
-// impl From<TransactionReturnData> for RpcTransactionReturnData {
-//     fn from(return_data: TransactionReturnData) -> Self {
-//         Self {
-//             program_id: return_data.program_id.to_string(),
-//             data: (base64::encode(return_data.data), ReturnDataEncoding::Base64),
-//         }
-//     }
-// }
-
-// #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, Hash, PartialEq)]
-// #[serde(rename_all = "camelCase")]
-// pub enum ReturnDataEncoding {
-//     Base64,
-// }
-
-// #[derive(Serialize, Deserialize, Clone, Debug)]
-// #[serde(rename_all = "camelCase")]
 // pub struct RpcStorageTurn {
 //     pub blockhash: String,
 //     pub slot: Slot,


### PR DESCRIPTION
- added both `simulate_transaction_with_config` and `simulate_transaction` methods to wasm solana client
- updated `SimulateTransactionResponse` to return the [object](https://docs.solana.com/api/http#simulatetransaction) that is expected from the `simulateTransaction` Http method instead of `Signature` type. Mirroring what is found in the [Solana RPC Client](https://github.com/solana-labs/solana/blob/6e5615e32dfd20730f9c3a65bb211512d867e103/rpc-client-api/src/response.rs#L416-#L424)