### PR TITLE
Make build script work on macOS and handle invalid theme key

### DIFF
--- a/client/src/utils/pg/theme/theme.ts
+++ b/client/src/utils/pg/theme/theme.ts
@@ -70,9 +70,16 @@ export class PgThemeManager {
     params.fontFamily ??=
       localStorage.getItem(this._FONT_KEY) ?? this._fonts[0].family;
 
-    const importableTheme = this._themes.find(
+    let importableTheme = this._themes.find(
       (t) => t.name === params.themeName
     )!;
+
+    if (importableTheme === undefined) {
+      importableTheme = this._themes[0];
+      params.themeName = importableTheme.name;
+      params.fontFamily = this._fonts[0].family;
+    }
+
     const font = this._fonts.find((f) => f.family === params.fontFamily)!;
 
     // Cloning the object because override functions expect the theme to be

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2506,7 +2506,7 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@solana-playground/anchor-cli@../wasm/anchor-cli/pkg":
-  version "0.26.0"
+  version "0.27.0"
 
 "@solana-playground/playnet@../wasm/pkgs/playnet":
   version "0.1.0"

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -81,7 +81,12 @@ build() {
 
     # Comment out the following line
     line="wasm.__wbg_systeminstruction_free(ptr);"
-    sed -i "s/$line/\/\/$line/" $package_dir/pkg/${package_name}_bg.js
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "s/$line/\/\/$line/" "$package_dir/pkg/${package_name}_bg.js"
+    else
+        sed -i "s/$line/\/\/$line/" "$package_dir/pkg/${package_name}_bg.js"
+    fi
 }
 
 if [ ${#args[@]} -ne 0 ]; then


### PR DESCRIPTION
On mac os the sed command needs an extra parameter to tell it not to backup the files. 
And the themes can have an old key, which doesn't exists, so i added a fallback to default theme. 