### PR TITLE
Migrate from deprecated seahorse-lang to seahorse-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | [num-traits](https://docs.rs/num-traits/0.2.16)                                    | 0.2.16  |
 | [pyth-sdk](https://docs.rs/pyth-sdk/0.8.0)                                         | 0.8.0   |
 | [pyth-sdk-solana](https://docs.rs/pyth-sdk-solana/0.8.0)                           | 0.8.0   |
+| [seahorse-dev](https://docs.rs/seahorse-dev/0.1.1)                                 | 0.1.1   |
 | [solana-program](https://docs.rs/solana-program/1.16.13)                           | 1.16.13 |
 | [spl-account-compression](https://docs.rs/sspl-account-compression/0.2.0)          | 0.2.0   |
 | [spl-associated-token-account](https://docs.rs/spl-associated-token-account/2.1.0) | 2.1.0   |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 | [num-traits](https://docs.rs/num-traits/0.2.16)                                    | 0.2.16  |
 | [pyth-sdk](https://docs.rs/pyth-sdk/0.8.0)                                         | 0.8.0   |
 | [pyth-sdk-solana](https://docs.rs/pyth-sdk-solana/0.8.0)                           | 0.8.0   |
-| [seahorse-dev](https://docs.rs/seahorse-dev/0.1.1)                                 | 0.1.1   |
 | [solana-program](https://docs.rs/solana-program/1.16.13)                           | 1.16.13 |
 | [spl-account-compression](https://docs.rs/sspl-account-compression/0.2.0)          | 0.2.0   |
 | [spl-associated-token-account](https://docs.rs/spl-associated-token-account/2.1.0) | 2.1.0   |

--- a/client/src/components/EditorWithTabs/Editor/Home/resources.ts
+++ b/client/src/components/EditorWithTabs/Editor/Home/resources.ts
@@ -24,7 +24,7 @@ export const RESOURCES: ResourceProps[] = [
   {
     title: "Seahorse",
     text: "Write Anchor-compatible Solana programs in Python.",
-    url: "https://seahorse-lang.org/docs/accounts/",
+    url: "https://www.seahorse.dev/using-seahorse/accounts",
     src: "https://pbs.twimg.com/profile_images/1556384244598964226/S3cx06I2_400x400.jpg",
     circleImage: true,
   },

--- a/client/src/frameworks/seahorse/files/src/fizzbuzz.py
+++ b/client/src/frameworks/seahorse/files/src/fizzbuzz.py
@@ -1,5 +1,5 @@
 # fizzbuzz
-# Built with Seahorse v0.2.7
+# Built with Seahorse v0.1.1
 #
 # On-chain, persistent FizzBuzz!
 

--- a/client/src/frameworks/seahorse/from.md
+++ b/client/src/frameworks/seahorse/from.md
@@ -2,7 +2,7 @@
 
 - Install tools
 
-Instructions on how to install [Seahorse](https://github.com/ameliatastic/seahorse-lang) can be found [here](https://seahorse-lang.org/docs/installation).
+Instructions on how to install [Seahorse](https://www.seahorse.dev) can be found [here](https://www.seahorse.dev/introduction/installation).
 
 - Install dependencies
 

--- a/client/src/frameworks/seahorse/from.ts
+++ b/client/src/frameworks/seahorse/from.ts
@@ -51,7 +51,7 @@ export const convertFromPlayground = async (files: TupleFiles) => {
     [
       PgCommon.joinPaths([SEAHORSE_PATH, "prelude.py"]),
       await PgCommon.fetchText(
-        "https://raw.githubusercontent.com/ameliatastic/seahorse-lang/main/data/const/seahorse_prelude.py"
+        "https://raw.githubusercontent.com/solana-developers/seahorse/main/data/const/seahorse_prelude.py"
       ),
     ]
   );

--- a/client/src/tutorials/HelloSeahorse/pages/1.md
+++ b/client/src/tutorials/HelloSeahorse/pages/1.md
@@ -1,6 +1,6 @@
 # Hello world program 🌍️
 
-We are going to be writing a [Hello world](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) program with [Seahorse](https://seahorse-lang.org/).
+We are going to be writing a [Hello world](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) program with [Seahorse](https://www.seahorse.dev/).
 
 Seahorse allows us to write programs in Python that transpiles into [Anchor](https://anchor-lang.com/) code.
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2645,7 +2645,7 @@
   version "0.99.4"
 
 "@solana-playground/seahorse-compile@../wasm/seahorse-compile/pkg":
-  version "0.2.7"
+  version "0.1.1"
 
 "@solana-playground/solana-cli@../wasm/solana-cli/pkg":
   version "1.11.0"

--- a/vscode/src/commands/create/seahorse.ts
+++ b/vscode/src/commands/create/seahorse.ts
@@ -13,7 +13,7 @@ export const processCreateSeahorse = async () => {
     [
       path.join(PATHS.DIRS.PROGRAMS_PY, `${name}.py`),
       `# ${name}
-# Built with Seahorse v0.2.7
+# Built with Seahorse v0.1.1
 
 from seahorse.prelude import *
 

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -130,7 +130,7 @@
     fastq "^1.6.0"
 
 "@solana-playground/seahorse-compile@../wasm/seahorse-compile/pkg":
-  version "0.2.7"
+  version "0.1.1"
 
 "@solana/buffer-layout@^4.0.0":
   version "4.0.0"

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2826,19 +2826,19 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "seahorse-compile-wasm"
-version = "0.2.7"
+version = "0.1.1"
 dependencies = [
  "console_error_panic_hook",
- "seahorse-lang",
+ "seahorse-dev",
  "solana-playground-utils-wasm",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "seahorse-lang"
-version = "0.2.7"
+name = "seahorse-dev"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272f119e5b1f4ae2ba6c8b0eef3c2e1ef214df58b7c16f7c8e5e2e94b55bb407"
+checksum = "49a695b5e3fbfa72d504721e1c82f2d2b16a5a20c726be4992ef1bed66b76d50"
 dependencies = [
  "base58",
  "clap",

--- a/wasm/seahorse-compile/Cargo.toml
+++ b/wasm/seahorse-compile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seahorse-compile-wasm"
-version = "0.2.7" # mirror seahorse-lang version
+version = "0.1.1" # mirror seahorse-dev version
 edition = "2021"
 authors = ["Callum McIntyre <callum.mcintyre@solana.com>"]
 description = "Seahorse compiler for Solana Playground with WASM."
@@ -12,6 +12,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_error_panic_hook = "*"
-seahorse-lang = "0.2.7"
+seahorse-dev = "0.1.1"
 solana-playground-utils-wasm = { path = "../utils/solana-playground-utils" }
 wasm-bindgen = "*"

--- a/wasm/seahorse-compile/src/lib.rs
+++ b/wasm/seahorse-compile/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{panic, path::PathBuf, str::FromStr};
 
-use seahorse_lang::core::{compile, Tree};
+use seahorse_dev::core::{compile, Tree};
 use solana_playground_utils_wasm::js::PgTerminal;
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
This is a part of the larger migration from the deprecated [seahorse-lang](https://seahorse-lang.org/) to [seahorse-dev](https://www.seahorse.dev/) which will be maintained by me.

Crate: https://crates.io/crates/seahorse-dev
Github: https://github.com/solana-developers/seahorse