### PR TITLE
Parallelize awaits

### DIFF
--- a/client/src/commands/deploy/deploy.ts
+++ b/client/src/commands/deploy/deploy.ts
@@ -132,8 +132,10 @@ const processDeploy = async () => {
   // Decide whether it's an initial deployment or an upgrade and calculate
   // how much SOL user needs before creating the buffer.
   const wallet = PgWallet.current!;
-  const userBalance = await connection.getBalance(wallet.publicKey);
-  const programExists = await connection.getAccountInfo(programPk);
+  const [programExists, userBalance] = await Promise.all([
+    connection.getAccountInfo(programPk),
+    connection.getBalance(wallet.publicKey),
+  ]);
 
   if (!programExists) {
     // Initial deploy

--- a/client/src/commands/sugar/commands/deploy/collection.ts
+++ b/client/src/commands/sugar/commands/deploy/collection.ts
@@ -33,42 +33,43 @@ export const createCollection = async (
 
   const payer = metaplex.identity().publicKey;
 
-  // Create mint account
-  const createMintAccountIx = await SystemProgram.createAccount({
-    fromPubkey: payer,
-    lamports: await metaplex.connection.getMinimumBalanceForRentExemption(
-      MINT_SIZE
-    ),
-    newAccountPubkey: collectionMintPk,
-    programId: TOKEN_PROGRAM_ID,
-    space: MINT_SIZE,
-  });
-
-  // Initialize mint
-  const initMintIx = await createInitializeMintInstruction(
-    collectionMintPk,
-    0,
-    payer,
-    payer
-  );
-
-  const ataPk = await getAssociatedTokenAddress(collectionMintPk, payer);
-
-  // Create associated account
-  const createAtaIx = await createAssociatedTokenAccountInstruction(
-    payer,
-    ataPk,
-    payer,
-    collectionMintPk
-  );
-
-  // Mint
-  const mintToIx = await createMintToInstruction(
-    collectionMintPk,
-    ataPk,
-    payer,
-    1
-  );
+  const [
+    blockhashInfo,
+    [createAtaIx, mintToIx],
+    createMintAccountIx,
+    initMintIx,
+  ] = await Promise.all([
+    // Fetch the latest blockhash to use to specify the transaction lifetime
+    metaplex.connection.getLatestBlockhash(),
+    // Get the [createAta, mintTo] instructions
+    (async () => {
+      const ataPk = await getAssociatedTokenAddress(collectionMintPk, payer);
+      return await Promise.all([
+        // Create associated account
+        createAssociatedTokenAccountInstruction(
+          payer,
+          ataPk,
+          payer,
+          collectionMintPk
+        ),
+        // Mint
+        createMintToInstruction(collectionMintPk, ataPk, payer, 1),
+      ]);
+    })(),
+    // Create mint account
+    (async () =>
+      SystemProgram.createAccount({
+        fromPubkey: payer,
+        lamports: await metaplex.connection.getMinimumBalanceForRentExemption(
+          MINT_SIZE
+        ),
+        newAccountPubkey: collectionMintPk,
+        programId: TOKEN_PROGRAM_ID,
+        space: MINT_SIZE,
+      }))(),
+    // Initialize mint
+    createInitializeMintInstruction(collectionMintPk, 0, payer, payer),
+  ]);
 
   const creator: Creator = {
     address: payer,
@@ -135,8 +136,6 @@ export const createCollection = async (
     ]
   );
   tx.feePayer = payer;
-
-  const blockhashInfo = await metaplex.connection.getLatestBlockhash();
   tx.recentBlockhash = blockhashInfo.blockhash;
 
   await metaplex

--- a/client/src/components/CodeBlock/highlight.ts
+++ b/client/src/components/CodeBlock/highlight.ts
@@ -26,8 +26,7 @@ export const highlight = async (
   theme: IRawTheme
 ) => {
   await initializeHighlighter();
-  await loadLanguage(lang as Lang);
-  await loadTheme(theme);
+  await Promise.all([loadLanguage(lang as Lang), loadTheme(theme)]);
 
   const tokens = highlighter.codeToThemedTokens(code, lang, theme.name);
   return renderToHtml(tokens, { bg: "inherit", themeName: theme.name });

--- a/client/src/components/EditorWithTabs/Editor/Monaco/languages/rust/rust-analyzer/rust-analyzer.ts
+++ b/client/src/components/EditorWithTabs/Editor/Monaco/languages/rust/rust-analyzer/rust-analyzer.ts
@@ -13,10 +13,6 @@ import {
 /** Monaco language id for Rust */
 const LANGUAGE_ID = "rust";
 
-function nonNullable<T>(value: T): value is NonNullable<T> {
-  return value !== null && value !== undefined;
-}
-
 /**
  * Cached crate names for Rust Analyzer.
  *
@@ -177,7 +173,7 @@ const update = async (model: monaco.editor.IModel) => {
         return null;
       }
     })
-    .filter(nonNullable);
+    .filter(PgCommon.isNonNullish);
   if (crateImportPromises.length) {
     await Promise.all(crateImportPromises);
   }
@@ -232,7 +228,7 @@ const loadDependency = async (
         return null;
       }
     })
-    .filter(nonNullable);
+    .filter(PgCommon.isNonNullish);
   if (crateImportPromises.length) {
     await Promise.all(crateImportPromises);
   }

--- a/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/declarations/declarations.ts
+++ b/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/declarations/declarations.ts
@@ -1,39 +1,29 @@
+import { declareDisposableTypes } from "./disposable";
+import { declareGlobalTypes } from "./global";
+import { declareImportableTypes } from "./importable";
 import type { Disposable } from "../../../../../../../utils/pg";
 
 /**
  * Initialize type declarations.
  *
  * Steps:
- * 1. Declare global types
+ * 1. Declare global and importable types
  * 2. Declare disposable types
- * 3. Declare importable types
  *
  * @returns a disposable to dispose all events
  */
 export const initDeclarations = async (): Promise<Disposable> => {
-  const [disposable, global, importable] = await Promise.all([
-    // Disposable declarations
-    (async () => {
-      const { declareDisposableTypes } = await import("./disposable");
-      return declareDisposableTypes();
-    })(),
-    // Global declarations
-    (async () => {
-      const { declareGlobalTypes } = await import("./global");
-      return await declareGlobalTypes();
-    })(),
-    // Importable declarations
-    (async () => {
-      const { declareImportableTypes } = await import("./importable");
-      return await declareImportableTypes();
-    })(),
+  const [global, importable] = await Promise.all([
+    declareGlobalTypes(),
+    declareImportableTypes(),
   ]);
+  const disposable = declareDisposableTypes();
 
   return {
     dispose: () => {
       global.dispose();
-      disposable.dispose();
       importable.dispose();
+      disposable.dispose();
     },
   };
 };

--- a/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/declarations/declarations.ts
+++ b/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/declarations/declarations.ts
@@ -11,17 +11,23 @@ import type { Disposable } from "../../../../../../../utils/pg";
  * @returns a disposable to dispose all events
  */
 export const initDeclarations = async (): Promise<Disposable> => {
-  // Global declarations
-  const { declareGlobalTypes } = await import("./global");
-  const global = await declareGlobalTypes();
-
-  // Disposable declarations
-  const { declareDisposableTypes } = await import("./disposable");
-  const disposable = declareDisposableTypes();
-
-  // Importable declarations
-  const { declareImportableTypes } = await import("./importable");
-  const importable = await declareImportableTypes();
+  const [disposable, global, importable] = await Promise.all([
+    // Disposable declarations
+    (async () => {
+      const { declareDisposableTypes } = await import("./disposable");
+      return declareDisposableTypes();
+    })(),
+    // Global declarations
+    (async () => {
+      const { declareGlobalTypes } = await import("./global");
+      return await declareGlobalTypes();
+    })(),
+    // Importable declarations
+    (async () => {
+      const { declareImportableTypes } = await import("./importable");
+      return await declareImportableTypes();
+    })(),
+  ]);
 
   return {
     dispose: () => {

--- a/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/declarations/global.ts
+++ b/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/declarations/global.ts
@@ -35,12 +35,16 @@ export const declareGlobalTypes = async (): Promise<Disposable> => {
     declareNamespace("solana-playground", { as: "pg" }),
   ];
 
-  for (const [packageName, importStyle] of PgCommon.entries(PACKAGES.global)) {
-    disposables.push(
-      (await declarePackage(packageName),
-      declareNamespace(packageName, importStyle))
-    );
-  }
+  await Promise.all(
+    PgCommon.entries(PACKAGES.global).map(
+      async ([packageName, importStyle]) => {
+        disposables.push(
+          (await declarePackage(packageName),
+          declareNamespace(packageName, importStyle))
+        );
+      }
+    )
+  );
 
   return { dispose: () => disposables.forEach(({ dispose }) => dispose()) };
 };

--- a/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/declarations/importable.ts
+++ b/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/declarations/importable.ts
@@ -30,24 +30,26 @@ const cachedTypes: {
  * @param code current editor content
  */
 const update = async (code: string) => {
-  for (const packageName of PACKAGES.importable) {
-    const pkg = cachedTypes[packageName];
-    if (pkg === true) continue;
+  await Promise.all(
+    PACKAGES.importable.map(async (packageName) => {
+      const pkg = cachedTypes[packageName];
+      if (pkg === true) return;
 
-    if (new RegExp(`("|')${packageName}("|')`, "gm").test(code)) {
-      await declarePackage(packageName);
+      if (new RegExp(`("|')${packageName}("|')`, "gm").test(code)) {
+        await declarePackage(packageName);
 
-      // Dispose the old filler declaration if it exists
-      pkg?.dispose();
+        // Dispose the old filler declaration if it exists
+        pkg?.dispose();
 
-      // Declaration is final, this package will not get declared again
-      cachedTypes[packageName] = true;
-    } else if (!pkg) {
-      // Empty declaration should get disposed if the package is used
-      cachedTypes[packageName] =
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(
-          declareModule(packageName)
-        );
-    }
-  }
+        // Declaration is final, this package will not get declared again
+        cachedTypes[packageName] = true;
+      } else if (!pkg) {
+        // Empty declaration should get disposed if the package is used
+        cachedTypes[packageName] =
+          monaco.languages.typescript.typescriptDefaults.addExtraLib(
+            declareModule(packageName)
+          );
+      }
+    })
+  );
 };

--- a/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/init.ts
+++ b/client/src/components/EditorWithTabs/Editor/Monaco/languages/typescript/init.ts
@@ -1,3 +1,4 @@
-import { initDeclarations } from "./declarations";
-
-export const init = () => initDeclarations();
+export const init = async () => {
+  const { initDeclarations } = await import("./declarations");
+  return await initDeclarations();
+};

--- a/client/src/frameworks/anchor/to.ts
+++ b/client/src/frameworks/anchor/to.ts
@@ -9,7 +9,7 @@ export const convertToPlayground = async (files: TupleFiles) => {
   const programNames = PgCommon.toUniqueArray(
     files
       .map(([path]) => /programs\/(.*?)\/src/.exec(path)?.[1])
-      .filter(Boolean) as string[]
+      .filter(PgCommon.isNonNullish)
   );
 
   // Handle multiple programs

--- a/client/src/utils/pg/common.ts
+++ b/client/src/utils/pg/common.ts
@@ -646,6 +646,17 @@ export class PgCommon {
   }
 
   /**
+   * Get whether the given value is non-nullish i.e. **not** `null` or
+   * `undefined`.
+   *
+   * @param value value to check
+   * @returns whether the given value is non-nullish
+   */
+  static isNonNullish<T>(value: T): value is NonNullable<T> {
+    return value !== null && value !== undefined;
+  }
+
+  /**
    * @returns camelCase converted version of the string input
    */
   static toCamelCase(str: string) {


### PR DESCRIPTION
Each commit in this PR rolls up serial awaits and await-in-a-loops into a `Promise.all()`

# Test Plan

I didn't _really_ test this rigorously.

I did however take some before/after Lighthouse scores loading the playground in a browser.

| Before | After |
|---|---|
|![image](https://github.com/solana-playground/solana-playground/assets/13243/663a3f49-6179-46cd-9ee0-7cb684f81490)|![image](https://github.com/solana-playground/solana-playground/assets/13243/650bd806-0fff-47e2-8968-ad2e70c92ce2)|