### PR TITLE
Update to seahorse-dev 0.2.0

### DIFF
--- a/client/src/frameworks/seahorse/files/src/fizzbuzz.py
+++ b/client/src/frameworks/seahorse/files/src/fizzbuzz.py
@@ -1,5 +1,5 @@
 # fizzbuzz
-# Built with Seahorse v0.1.1
+# Built with Seahorse v0.2.0
 #
 # On-chain, persistent FizzBuzz!
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2665,7 +2665,7 @@
   version "0.99.4"
 
 "@solana-playground/seahorse-compile@../wasm/seahorse-compile/pkg":
-  version "0.1.1"
+  version "0.2.0"
 
 "@solana-playground/solana-cli@../wasm/solana-cli/pkg":
   version "1.11.0"

--- a/vscode/src/commands/create/seahorse.ts
+++ b/vscode/src/commands/create/seahorse.ts
@@ -13,7 +13,7 @@ export const processCreateSeahorse = async () => {
     [
       path.join(PATHS.DIRS.PROGRAMS_PY, `${name}.py`),
       `# ${name}
-# Built with Seahorse v0.1.1
+# Built with Seahorse v0.2.0
 
 from seahorse.prelude import *
 

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -130,7 +130,7 @@
     fastq "^1.6.0"
 
 "@solana-playground/seahorse-compile@../wasm/seahorse-compile/pkg":
-  version "0.1.1"
+  version "0.2.0"
 
 "@solana/buffer-layout@^4.0.0":
   version "4.0.0"

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2826,7 +2826,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "seahorse-compile-wasm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "seahorse-dev",
@@ -2836,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "seahorse-dev"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a695b5e3fbfa72d504721e1c82f2d2b16a5a20c726be4992ef1bed66b76d50"
+checksum = "d3af486d9927b4e2b6cc7abb53d796c61a11255b70fdf07c6c144311904411a4"
 dependencies = [
  "base58",
  "clap",

--- a/wasm/seahorse-compile/Cargo.toml
+++ b/wasm/seahorse-compile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seahorse-compile-wasm"
-version = "0.1.1" # mirror seahorse-dev version
+version = "0.2.0" # mirror seahorse-dev version
 edition = "2021"
 authors = ["Callum McIntyre <callum.mcintyre@solana.com>"]
 description = "Seahorse compiler for Solana Playground with WASM."
@@ -12,6 +12,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_error_panic_hook = "*"
-seahorse-dev = "0.1.1"
+seahorse-dev = "0.2.0"
 solana-playground-utils-wasm = { path = "../utils/solana-playground-utils" }
 wasm-bindgen = "*"


### PR DESCRIPTION
- Update Playground to the latest version of Seahorse
- Most importantly, includes https://github.com/solana-developers/seahorse/pull/10 which fixes Seahorse for Anchor 0.29.0