### PR TITLE
feat: add calyptus curriculum to tutrials in homepage

### DIFF
--- a/client/src/components/EditorWithTabs/Editor/Home/tutorials.ts
+++ b/client/src/components/EditorWithTabs/Editor/Home/tutorials.ts
@@ -20,4 +20,8 @@ export const TUTORIALS: TutorialProps[] = [
     title: "A Guide to Full Stack Development on Solana",
     url: "https://dev.to/edge-and-node/the-complete-guide-to-full-stack-solana-development-with-react-anchor-rust-and-phantom-3291",
   },
+  {
+    title: "Learn how to build production-ready Dapps, Tokens and NFTs on Solana.",
+    url: "https://calyptus.co/learn-solana/",
+  },
 ];


### PR DESCRIPTION
add the Calyptus Solana curriculum, `https://calyptus.co/learn-solana/` to tutorials.
