### PR TITLE
Allow pasting into fields in test UI

### DIFF
--- a/client/src/components/SearchBar/SearchBar.tsx
+++ b/client/src/components/SearchBar/SearchBar.tsx
@@ -341,7 +341,7 @@ const SearchBar: FC<SearchBarProps> = ({
             if (item) {
               // `item.value` can be an empty string because it's not updated as
               // soon as `onPaste` executes.
-              if (typeof item === "object") item.value = clipboardText;
+              if (typeof item === "object") item.value ||= clipboardText;
 
               // Include a timeout otherwise the pasted text is appended to the
               // value we set instead of overriding it

--- a/client/src/components/SearchBar/SearchBar.tsx
+++ b/client/src/components/SearchBar/SearchBar.tsx
@@ -95,12 +95,13 @@ const SearchBar: FC<SearchBarProps> = ({
     if (opts?.focus) input.focus();
   };
   const getItemValue = (item: NormalizedItem) => {
+    const currentValue = inputRef.current?.value ?? props.value;
     return item.value !== undefined
       ? typeof item.value === "string"
         ? item.value
         : typeof item.value === "function"
-        ? item.value(props.value)
-        : props.value
+        ? item.value(currentValue)
+        : currentValue
       : item.label;
   };
 

--- a/client/src/components/SearchBar/SearchBar.tsx
+++ b/client/src/components/SearchBar/SearchBar.tsx
@@ -341,7 +341,7 @@ const SearchBar: FC<SearchBarProps> = ({
             if (item) {
               // `item.value` can be an empty string because it's not updated as
               // soon as `onPaste` executes.
-              if (typeof item === "object") item.value ||= clipboardText;
+              if (typeof item === "object") item.value = clipboardText;
 
               // Include a timeout otherwise the pasted text is appended to the
               // value we set instead of overriding it


### PR DESCRIPTION
I'm not 100% about this fix, I might be missing some nuance about how search bar items work

But the reason pasting was not working is because `item.value ||= clipboardText` was never updating, because `item.value` was truthy:
<img width="535" alt="Screenshot 2024-01-25 at 10 13 24" src="https://github.com/solana-playground/solana-playground/assets/1711350/a1181b03-a04f-4ef0-adbf-8c1f1a94b5ca">

This PR changes it to always replace `item.value` with the pasted text

~~An alternative fix would be to remove the `{current: true}` from the Custom item, so that `item.value` is just whatever that field contains, but I'm not sure what that represents/would do.~~
Actually I guess that wouldn't work because then you couldn't paste unless the field was empty. I'm not sure if there are circumstances where we shouldn't change `item.value` on paste though. 

Fixes #188 