### PR TITLE
Quick fix to reenable pasting from clipboard into SearchBar for seeds/account addresses

### DIFF
--- a/client/src/components/SearchBar/SearchBar.tsx
+++ b/client/src/components/SearchBar/SearchBar.tsx
@@ -341,7 +341,7 @@ const SearchBar: FC<SearchBarProps> = ({
             if (item) {
               // `item.value` can be an empty string because it's not updated as
               // soon as `onPaste` executes.
-              if (typeof item === "object") item.value ||= clipboardText;
+              if (typeof item === "object") item.value = clipboardText;
 
               // Include a timeout otherwise the pasted text is appended to the
               // value we set instead of overriding it


### PR DESCRIPTION
I discovered a major UI bug during a live coding presentation this morning that prevented me from pasting from clipboard into seeds/account addresses on https://beta.solpg.io

This is a quick, one-line fix that is tested and working locally. I do not know the wider implications of these code changes, as the repo is quite large and complex, but I would recommend merging this or coming up with a fix ASAP to fix the bug.

Kind regards,
Dean.