### PR TITLE
feat: decouple cli from sdk, fix unit tests, upgrade clap to 4

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,7 +135,7 @@ dependencies = [
  "anchor-lang",
  "anchor-syn",
  "anyhow",
- "clap",
+ "clap 4.5.4",
  "console",
  "console_error_panic_hook",
  "flate2",
@@ -234,10 +243,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.58"
+name = "anstream"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "ark-bn254"
@@ -425,6 +483,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide 0.7.3",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base58"
@@ -747,9 +820,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
 dependencies = [
  "jobserver",
  "libc",
@@ -790,13 +863,35 @@ checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.7",
+ "clap_lex 0.2.4",
  "indexmap 1.9.1",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.5.4",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.7.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -813,6 +908,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +942,12 @@ checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "combine"
@@ -1044,7 +1163,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.52",
 ]
 
@@ -1164,7 +1283,7 @@ dependencies = [
  "lazy_static",
  "regex",
  "serde",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -1285,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -1476,6 +1595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "h2"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1663,12 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1644,7 +1775,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1757,6 +1888,12 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1992,15 +2129,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.4"
+name = "miniz_oxide"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2136,10 +2281,19 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2342,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2810,6 +2964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,7 +3073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3af486d9927b4e2b6cc7abb53d796c61a11255b70fdf07c6c144311904411a4"
 dependencies = [
  "base58",
- "clap",
+ "clap 3.2.8",
  "heck 0.4.0",
  "owo-colors",
  "proc-macro2",
@@ -3111,6 +3271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,11 +3330,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "solana-clap-v3-utils-wasm"
 version = "1.11.0"
 dependencies = [
  "chrono",
- "clap",
+ "clap 4.5.4",
  "rpassword",
  "solana-remote-wallet",
  "solana-sdk",
@@ -3195,7 +3374,7 @@ version = "1.11.0"
 dependencies = [
  "base64 0.13.0",
  "chrono",
- "clap",
+ "clap 4.5.4",
  "console",
  "humantime",
  "pretty-hex",
@@ -3215,7 +3394,7 @@ name = "solana-cli-wasm"
 version = "1.11.0"
 dependencies = [
  "bs58 0.4.0",
- "clap",
+ "clap 3.2.8",
  "console",
  "console_error_panic_hook",
  "const_format",
@@ -3242,11 +3421,12 @@ dependencies = [
 name = "solana-client-wasm"
 version = "1.18.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.13.0",
  "bincode",
  "bs58 0.4.0",
- "clap",
+ "clap 4.5.4",
  "futures",
  "js-sys",
  "reqwest",
@@ -3256,6 +3436,7 @@ dependencies = [
  "solana-extra-wasm",
  "solana-sdk",
  "thiserror",
+ "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -3275,7 +3456,7 @@ dependencies = [
  "bs58 0.4.0",
  "bytemuck",
  "chrono",
- "clap",
+ "clap 3.2.8",
  "console",
  "fluvio-wasm-timer",
  "humantime",
@@ -3523,7 +3704,7 @@ dependencies = [
 name = "spl-token-cli-wasm"
 version = "2.0.15"
 dependencies = [
- "clap",
+ "clap 4.5.4",
  "console",
  "console_error_panic_hook",
  "serde",
@@ -3584,6 +3765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3615,7 +3802,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 name = "sugar-cli-wasm"
 version = "1.1.0-alpha+CMv3"
 dependencies = [
- "clap",
+ "clap 4.5.4",
  "js-sys",
  "solana-playground-utils-wasm",
  "wasm-bindgen",
@@ -3764,18 +3951,32 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
- "once_cell",
+ "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
- "socket2",
- "winapi",
+ "signal-hook-registry",
+ "socket2 0.5.7",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4022,6 +4223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4218,6 +4425,15 @@ dependencies = [
  "windows_i686_msvc 0.36.1",
  "windows_x86_64_gnu 0.36.1",
  "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.1",
 ]
 
 [[package]]

--- a/wasm/solana-client/Cargo.toml
+++ b/wasm/solana-client/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["solana", "wasm", "client", "rpc", "playground"]
 readme = "README.md"
 
 [features]
+cli = ["clap"]
 pubsub = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 
 [dependencies]
@@ -18,7 +19,7 @@ async-trait = "0.1"
 base64 = "0.13"
 bincode = "1.3"
 bs58 = "0.4"
-clap = "3.1.18"
+clap = { version = "4.5.4" , optional = true  }
 futures = "0.3"
 js-sys = { version = "0.3.65", optional = true }
 reqwest = { version = "0.11.9", features = ["json"] }
@@ -33,4 +34,6 @@ wasm-bindgen-futures = { version = "0.4.38", optional = true }
 web-sys = { version = "0.3.65", features = ["MessageEvent", "WebSocket"], optional = true }
 
 [dev-dependencies]
+anyhow = "1.0.86"
+tokio = { version = "1.38.0", features = ["full"] }
 wasm-bindgen-test = "0.3.38"

--- a/wasm/solana-client/src/utils/clap.rs
+++ b/wasm/solana-client/src/utils/clap.rs
@@ -1,12 +1,14 @@
-// These utilities are copied from solana-clap-v3-utils-wasm
+// These utilities are copied and adapted from solana-clap-v3-utils-wasm
 // We don't need/want to upload solana-clap-v3-utils-wasm to crates.io
 
+#[cfg(feature = "cli")]
 pub struct ArgConstant<'a> {
     pub long: &'a str,
     pub name: &'a str,
     pub help: &'a str,
 }
 
+#[cfg(feature = "cli")]
 pub mod input_parsers {
     use clap::ArgMatches;
     use solana_sdk::{
@@ -19,7 +21,7 @@ pub mod input_parsers {
         T: std::str::FromStr,
         <T as std::str::FromStr>::Err: std::fmt::Debug,
     {
-        if let Some(value) = matches.value_of(name) {
+        if let Some(value) = matches.get_one::<String>(name) {
             value.parse::<T>().ok()
         } else {
             None
@@ -37,6 +39,7 @@ pub mod input_parsers {
     }
 }
 
+#[cfg(feature = "cli")]
 pub mod nonce {
     use super::ArgConstant;
 
@@ -50,6 +53,7 @@ pub mod nonce {
     };
 }
 
+#[cfg(feature = "cli")]
 pub mod offline {
     use super::ArgConstant;
 

--- a/wasm/solana-client/src/utils/mod.rs
+++ b/wasm/solana-client/src/utils/mod.rs
@@ -4,4 +4,5 @@ pub mod rpc_filter;
 pub mod rpc_request;
 pub mod rpc_response;
 
+#[cfg(feature = "cli")]
 mod clap;

--- a/wasm/solana-client/src/utils/nonce_utils.rs
+++ b/wasm/solana-client/src/utils/nonce_utils.rs
@@ -106,9 +106,9 @@ pub fn account_identity_ok<T: ReadableAccount>(account: &T) -> Result<(), NonceE
 /// Determine if a nonce account is initialized:
 ///
 /// ```no_run
-/// use solana_client::{
-///     rpc_client::WasmClient,
-///     nonce_utils,
+/// use solana_client_wasm::{
+///     WasmClient,
+///     utils::nonce_utils::{self, NonceError},
 /// };
 /// use solana_sdk::{
 ///     nonce::State,
@@ -116,24 +116,25 @@ pub fn account_identity_ok<T: ReadableAccount>(account: &T) -> Result<(), NonceE
 /// };
 /// use anyhow::Result;
 ///
-/// fn is_nonce_initialized(
+/// #[tokio::main]
+/// async fn is_nonce_initialized(
 ///     client: &WasmClient,
 ///     nonce_account_pubkey: &Pubkey,
 /// ) -> Result<bool> {
 ///
 ///     // Sign the tx with nonce_account's `blockhash` instead of the
 ///     // network's latest blockhash.
-///     let nonce_account = client.get_account(nonce_account_pubkey)?;
+///     let nonce_account = client.get_account(nonce_account_pubkey).await.unwrap();
 ///     let nonce_state = nonce_utils::state_from_account(&nonce_account)?;
 ///
 ///     Ok(!matches!(nonce_state, State::Uninitialized))
 /// }
-/// #
-/// # let client = WasmClient::new(String::new());
-/// # let nonce_account_pubkey = Pubkey::new_unique();
-/// # is_nonce_initialized(&client, &nonce_account_pubkey)?;
-/// #
-/// # Ok::<(), anyhow::NonceError>(())
+///
+/// let client = WasmClient::new(&String::new());
+/// let nonce_account_pubkey = Pubkey::new_unique();
+/// is_nonce_initialized(&client, &nonce_account_pubkey).unwrap();
+///
+/// Ok::<(), NonceError>(())
 /// ```
 pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
     account: &T,
@@ -157,9 +158,9 @@ pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
 /// Create and sign a transaction with a durable nonce:
 ///
 /// ```no_run
-/// use solana_client::{
-///     rpc_client::WasmClient,
-///     nonce_utils,
+/// use solana_client_wasm::{
+///     WasmClient,
+///     utils::nonce_utils::{self, NonceError},
 /// };
 /// use solana_sdk::{
 ///     message::Message,
@@ -170,9 +171,9 @@ pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
 /// };
 /// use std::path::Path;
 /// use anyhow::Result;
-/// # use anyhow::anyhow;
 ///
-/// fn create_transfer_tx_with_nonce(
+/// #[tokio::main]
+/// async fn create_transfer_tx_with_nonce(
 ///     client: &WasmClient,
 ///     nonce_account_pubkey: &Pubkey,
 ///     payer: &Keypair,
@@ -207,7 +208,7 @@ pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
 ///
 ///     // Sign the tx with nonce_account's `blockhash` instead of the
 ///     // network's latest blockhash.
-///     let nonce_account = client.get_account(nonce_account_pubkey)?;
+///     let nonce_account = client.get_account(nonce_account_pubkey).await.unwrap();
 ///     let nonce_data = nonce_utils::data_from_account(&nonce_account)?;
 ///     let blockhash = nonce_data.blockhash();
 ///
@@ -218,18 +219,18 @@ pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
 ///
 ///     Ok(())
 /// }
-/// #
-/// # fn save_tx_to_file(path: &Path, tx: &Transaction) -> Result<()> {
-/// #     Ok(())
-/// # }
-/// #
-/// # let client = WasmClient::new(String::new());
-/// # let nonce_account_pubkey = Pubkey::new_unique();
-/// # let payer = Keypair::new();
-/// # let receiver = Pubkey::new_unique();
-/// # create_transfer_tx_with_nonce(&client, &nonce_account_pubkey, &payer, &receiver, 1024, Path::new("new_tx"))?;
-/// #
-/// # Ok::<(), anyhow::NonceError>(())
+///
+/// fn save_tx_to_file(path: &Path, tx: &Transaction) -> Result<()> {
+///     Ok(())
+/// }
+///
+/// let client = WasmClient::new(&String::new());
+/// let nonce_account_pubkey = Pubkey::new_unique();
+/// let payer = Keypair::new();
+/// let receiver = Pubkey::new_unique();
+/// create_transfer_tx_with_nonce(&client, &nonce_account_pubkey, &payer, &receiver, 1024, Path::new("new_tx")).unwrap();
+///
+/// Ok::<(), NonceError>(())
 /// ```
 pub fn data_from_account<T: ReadableAccount + StateMut<Versions>>(
     account: &T,

--- a/wasm/solana-client/src/utils/rpc_config.rs
+++ b/wasm/solana-client/src/utils/rpc_config.rs
@@ -1,5 +1,4 @@
 use bincode::serialize;
-use clap::ArgMatches;
 use solana_extra_wasm::{
     account_decoder::{UiAccount, UiAccountEncoding, UiDataSliceConfig},
     transaction_status::{TransactionDetails, UiTransactionEncoding},
@@ -12,14 +11,17 @@ use solana_sdk::{
     signature::Signature,
 };
 
-use super::{
-    clap::{
-        input_parsers::{pubkey_of, value_of},
-        nonce::NONCE_ARG,
-        offline::{BLOCKHASH_ARG, SIGN_ONLY_ARG},
-    },
-    rpc_filter::RpcFilterType,
+#[cfg(feature = "cli")]
+use clap::ArgMatches;
+
+#[cfg(feature = "cli")]
+use super::clap::{
+    input_parsers::{pubkey_of, value_of},
+    nonce::NONCE_ARG,
+    offline::{BLOCKHASH_ARG, SIGN_ONLY_ARG},
 };
+
+use super::rpc_filter::RpcFilterType;
 use crate::{utils::nonce_utils, ClientError, ClientResult, WasmClient};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -103,11 +105,14 @@ impl BlockhashQuery {
         }
     }
 
+    #[cfg(feature = "cli")]
     pub fn new_from_matches(matches: &ArgMatches) -> Self {
         let blockhash = value_of(matches, BLOCKHASH_ARG.name);
-        let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
+        let sign_only = matches
+            .get_one(SIGN_ONLY_ARG.name)
+            .expect("`sign_only`is required");
         let nonce_account = pubkey_of(matches, NONCE_ARG.name);
-        BlockhashQuery::new(blockhash, sign_only, nonce_account)
+        BlockhashQuery::new(blockhash, *sign_only, nonce_account)
     }
 
     pub async fn get_blockhash(


### PR DESCRIPTION
Currently installing the client will install clap as a dep which shouldn't be mandatory, so I decoupled it and moved it into separate feature only available if enabled. I have also fixed unit tests, and upgraded clap to 4.