### PR TITLE
Ensure wasm-pack is installed before trying to build locally in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ You can open an issue to request more crates.
 
 ## Run locally
 
-Install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/):
+Install [`wasm-pack`](https://rustwasm.github.io/wasm-pack):
+
 ```sh
-curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-```
+cargo install wasm-pack@0.10.3 --locked
 
 You can run the client locally by cloning the repository and running the following commands in the project directory.
 


### PR DESCRIPTION
Ensure wasm-pack is installed before trying to build locally in README: 

wasm-pack: https://rustwasm.github.io/wasm-pack/installer/

If not installed yarn will output `../wasm/build.sh: line 86: wasm-pack: command not found` when attempting to build locally.