### PR TITLE
fix: print_player() in Tiny Tutorial

### DIFF
--- a/client/src/tutorials/TinyAdventure/files/lib.rs
+++ b/client/src/tutorials/TinyAdventure/files/lib.rs
@@ -39,16 +39,10 @@ mod tiny_adventure {
 }
 
 fn print_player(player_position: u8) {
-    if player_position == 0 {
-        msg!("A Journey Begins!");
-        msg!("o.......");
-    } else if player_position == 1 {
+    if player_position == 1 {
         msg!("..o.....");
     } else if player_position == 2 {
         msg!("....o...");
-    } else if player_position == 3 {
-        msg!("........\\o/");
-        msg!("You have reached the end! Super!");
     }
 }
 


### PR DESCRIPTION
Removed the 0 & 3 cases from the function, because `print_player()` can never be called when the player's position is equal to either `0` or `3` (these cases are handled explicitly in the `move_left()` and `move_right()` functions).