### PR TITLE
fix: call moveRight() with the correct password

### DIFF
--- a/client/src/tutorials/TinyAdventureTwo/files/client.ts.raw
+++ b/client/src/tutorials/TinyAdventureTwo/files/client.ts.raw
@@ -53,7 +53,7 @@ console.log("o........💎");
 // Here we move to the right three times and collect the chest at the end of the level
 for (let i = 0; i < 3; i++) {
   txHash = await pg.program.methods
-    .moveRight()
+    .moveRight("gib")
     .accounts({
       chestVault: chestVaultAccount,
       gameDataAccount: globalLevel1GameDataAccount,


### PR DESCRIPTION
Not passing a password when calling the `moveRight()` function leads to the user being charged the 0.10 SOL without any way of recovering it.