### PR TITLE
Add support of jupiter-cpi crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 | [borsh-derive](https://docs.rs/borsh-derive/0.10.3)                                | 0.10.3  |
 | [bytemuck](https://docs.rs/bytemuck/1.14.0)                                        | 1.14.0  |
 | [bytemuck_derive](https://docs.rs/bytemuck_derive/1.5.0)                           | 1.5.0   |
-| [jupiter-cpi](https://docs.rs/jupiter-cpi/4.0.3)                                       | 4.0.3   |
+| [jupiter-cpi](https://docs.rs/jupiter-cpi/4.0.3)                                   | 4.0.3   |
 | [mpl-bubblegum](https://docs.rs/mpl-bubblegum/1.0.0)                               | 1.0.0   |
 | [mpl-token-auth-rules](https://docs.rs/mpl-token-auth-rules/1.4.3)                 | 1.4.3   |
 | [mpl-token-metadata](https://docs.rs/mpl-token-metadata/3.2.3)                     | 3.2.3   |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 | [borsh-derive](https://docs.rs/borsh-derive/0.10.3)                                | 0.10.3  |
 | [bytemuck](https://docs.rs/bytemuck/1.14.0)                                        | 1.14.0  |
 | [bytemuck_derive](https://docs.rs/bytemuck_derive/1.5.0)                           | 1.5.0   |
-| [jup-cpi](https://docs.rs/jupiter-cpi/4.0.3)                                       | 4.0.3   |
+| [jupiter-cpi](https://docs.rs/jupiter-cpi/4.0.3)                                       | 4.0.3   |
 | [mpl-bubblegum](https://docs.rs/mpl-bubblegum/1.0.0)                               | 1.0.0   |
 | [mpl-token-auth-rules](https://docs.rs/mpl-token-auth-rules/1.4.3)                 | 1.4.3   |
 | [mpl-token-metadata](https://docs.rs/mpl-token-metadata/3.2.3)                     | 3.2.3   |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@
 | [switchboard-solana](https://docs.rs/switchboard-solana/0.29.79)                   | 0.29.79 |
 | [switchboard-v2](https://docs.rs/switchboard-v2/0.4.0)                             | 0.4.0   |
 | [thiserror](https://docs.rs/thiserror/1.0.48)                                      | 1.0.48  |
-| [thiserror](https://docs.rs/thiserror/1.0.48)                                      | 1.0.48  |
 
 You can open an issue to request more crates.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 | [borsh-derive](https://docs.rs/borsh-derive/0.10.3)                                | 0.10.3  |
 | [bytemuck](https://docs.rs/bytemuck/1.14.0)                                        | 1.14.0  |
 | [bytemuck_derive](https://docs.rs/bytemuck_derive/1.5.0)                           | 1.5.0   |
+| [jup-cpi](https://docs.rs/jupiter-cpi/4.0.3)                                       | 4.0.3   |
 | [mpl-bubblegum](https://docs.rs/mpl-bubblegum/1.0.0)                               | 1.0.0   |
 | [mpl-token-auth-rules](https://docs.rs/mpl-token-auth-rules/1.4.3)                 | 1.4.3   |
 | [mpl-token-metadata](https://docs.rs/mpl-token-metadata/3.2.3)                     | 3.2.3   |
@@ -33,6 +34,7 @@
 | [spl-type-length-value](https://docs.rs/spl-type-length-value/0.3.0)               | 0.3.0   |
 | [switchboard-solana](https://docs.rs/switchboard-solana/0.29.79)                   | 0.29.79 |
 | [switchboard-v2](https://docs.rs/switchboard-v2/0.4.0)                             | 0.4.0   |
+| [thiserror](https://docs.rs/thiserror/1.0.48)                                      | 1.0.48  |
 | [thiserror](https://docs.rs/thiserror/1.0.48)                                      | 1.0.48  |
 
 You can open an issue to request more crates.

--- a/server/programs/Cargo.toml
+++ b/server/programs/Cargo.toml
@@ -19,6 +19,7 @@ borsh = "*"
 borsh-derive = "*"
 bytemuck = "*"
 bytemuck_derive = "*"
+jupiter-cpi = { git = "https://github.com/jup-ag/jupiter-cpi", rev = "5eb8977" }
 mpl-bubblegum = "*"
 mpl-token-auth-rules = { version = "*", features = ["no-entrypoint"] }
 mpl-token-metadata = "*"

--- a/supported-crates.json
+++ b/supported-crates.json
@@ -6,6 +6,7 @@
   "borsh-derive": "0.10.3",
   "bytemuck": "1.14.0",
   "bytemuck_derive": "1.5.0",
+  "jupiter-cpi": "4.0.3",
   "mpl-bubblegum": "1.0.0",
   "mpl-token-auth-rules": "1.4.3",
   "mpl-token-metadata": "3.2.3",


### PR DESCRIPTION
Adding jupiter-cpi would allow users to interact with pretty much all swap functions on Solana.

Hopefully I did it right, added the crate in Cargo.toml as the documentation recommanded: https://station.jup.ag/docs/apis/cpi


Have a nice evening.