### PR TITLE
Upgrade TypeScript from 4.9.5 to 5.0.4

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,7 @@
     "shiki": "^0.14.4",
     "stream-browserify": "^3.0.0",
     "styled-components": "^5.3.3",
-    "typescript": "=4.9.5",
+    "typescript": "=5.0.4",
     "vscode-oniguruma": "^1.7.0",
     "vscode-textmate": "^9.0.0",
     "xterm": "^4.18.0",
@@ -77,7 +77,8 @@
   },
   "resolutions": {
     "@solana/buffer-layout": "^4.0.0",
-    "styled-components": "^5"
+    "styled-components": "^5",
+    "typescript": "5.0.4"
   },
   "engines": {
     "node": ">=22.20.0"
@@ -85,7 +86,8 @@
   "scripts": {
     "setup": "git submodule update --init && yarn build-wasm && yarn generate",
     "start": "yarn generate && craco start",
-    "build": "yarn generate && GENERATE_SOURCEMAP=false craco build",
+    "build": "yarn generate && yarn run build-craco",
+    "build-craco": "GENERATE_SOURCEMAP=false craco build",
     "build-wasm": "build=\"../wasm/build.sh\" && chmod +x $build && $build --update",
     "format": "prettier --write src/",
     "check-format": "prettier --check src/",
@@ -94,7 +96,10 @@
     "generate-exports": "node scripts/generate-exports.mjs",
     "generate-packages": "node scripts/generate-packages.mjs",
     "generate-tutorials": "node scripts/generate-tutorials.mjs",
-    "sync-readme": "node scripts/sync-readme.mjs"
+    "sync-readme": "node scripts/sync-readme.mjs",
+    "test": "yarn run test-types && yarn run build-craco",
+    "test-build": "yarn run build-craco",
+    "test-types": "tsc --noEmit"
   },
   "eslintConfig": {
     "extends": [

--- a/client/package.json
+++ b/client/package.json
@@ -86,8 +86,7 @@
   "scripts": {
     "setup": "git submodule update --init && yarn build-wasm && yarn generate",
     "start": "yarn generate && craco start",
-    "build": "yarn generate && yarn run build-craco",
-    "build-craco": "GENERATE_SOURCEMAP=false craco build",
+    "build": "yarn generate && GENERATE_SOURCEMAP=false craco build",
     "build-wasm": "build=\"../wasm/build.sh\" && chmod +x $build && $build --update",
     "format": "prettier --write src/",
     "check-format": "prettier --check src/",

--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
     "crypto-browserify": "^3.12.0",
     "jszip": "^3.10.1",
     "mocha": "^10.0.0",
-    "monaco-editor": "=0.36.1",
+    "monaco-editor": "=0.37.1",
     "pako": "^2.1.0",
     "prettier": "^2.7.1",
     "process": "^0.11.10",

--- a/client/package.json
+++ b/client/package.json
@@ -97,7 +97,6 @@
     "generate-tutorials": "node scripts/generate-tutorials.mjs",
     "sync-readme": "node scripts/sync-readme.mjs",
     "test": "yarn test-types && yarn build",
-    "test-build": "yarn run build-craco",
     "test-types": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/client/package.json
+++ b/client/package.json
@@ -96,7 +96,7 @@
     "generate-packages": "node scripts/generate-packages.mjs",
     "generate-tutorials": "node scripts/generate-tutorials.mjs",
     "sync-readme": "node scripts/sync-readme.mjs",
-    "test": "yarn run test-types && yarn run build-craco",
+    "test": "yarn test-types && yarn build",
     "test-build": "yarn run build-craco",
     "test-types": "tsc --noEmit"
   },

--- a/client/src/settings/create.tsx
+++ b/client/src/settings/create.tsx
@@ -23,7 +23,7 @@ export const createSetting = <
     .join(" ");
 
   if (!(setting.getValue && setting.setValue && setting.onChange)) {
-    setting.getValue = () => PgCommon.getValue(PgSettings, id);
+    setting.getValue = () => PgCommon.getValue(PgSettings, id) as V;
     setting.setValue = (v) => PgCommon.setValue(PgSettings, id, v);
     setting.onChange = PgSettings[
       id.reduce(

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -2,7 +2,7 @@ import type {
   AllPartial,
   Disposable,
   Promisable,
-  StringKeys,
+  KeyOf,
   SyncOrAsync,
   Arrayable,
   ValueOf,
@@ -312,7 +312,7 @@ export class PgCommon {
   static setDefault<T, D extends AllPartial<T>>(value: T, defaultValue: D) {
     value ??= {} as T;
     for (const property in defaultValue) {
-      type K = StringKeys<T>;
+      type K = KeyOf<T>;
       const result = defaultValue[property] as AllPartial<T[K]>;
       value[property as K] ??= result as T[K];
     }
@@ -448,7 +448,7 @@ export class PgCommon {
    * @returns the object keys as an array
    */
   static keys<T extends Record<string, unknown>>(obj: T) {
-    return Object.keys(obj) as Array<StringKeys<T>>;
+    return Object.keys(obj) as Array<KeyOf<T>>;
   }
 
   /**
@@ -458,7 +458,7 @@ export class PgCommon {
    * @returns the object entries as an array of [key, value] tuples
    */
   static entries<T extends Record<string, unknown>>(obj: T) {
-    return Object.entries(obj) as Array<[StringKeys<T>, ValueOf<T>]>;
+    return Object.entries(obj) as Array<[KeyOf<T>, ValueOf<T>]>;
   }
 
   /**

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -2,6 +2,7 @@ import type {
   AllPartial,
   Disposable,
   Promisable,
+  StringKeys,
   SyncOrAsync,
   Arrayable,
   ValueOf,
@@ -311,7 +312,7 @@ export class PgCommon {
   static setDefault<T, D extends AllPartial<T>>(value: T, defaultValue: D) {
     value ??= {} as T;
     for (const property in defaultValue) {
-      type K = Extract<keyof T, string>;
+      type K = StringKeys<T>;
       const result = defaultValue[property] as AllPartial<T[K]>;
       value[property as K] ??= result as T[K];
     }
@@ -447,7 +448,7 @@ export class PgCommon {
    * @returns the object keys as an array
    */
   static keys<T extends Record<string, unknown>>(obj: T) {
-    return Object.keys(obj) as Array<Extract<keyof T, string>>;
+    return Object.keys(obj) as Array<StringKeys<T>>;
   }
 
   /**
@@ -457,7 +458,7 @@ export class PgCommon {
    * @returns the object entries as an array of [key, value] tuples
    */
   static entries<T extends Record<string, unknown>>(obj: T) {
-    return Object.entries(obj) as Array<[Extract<keyof T, string>, ValueOf<T>]>;
+    return Object.entries(obj) as Array<[StringKeys<T>, ValueOf<T>]>;
   }
 
   /**

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -311,8 +311,9 @@ export class PgCommon {
   static setDefault<T, D extends AllPartial<T>>(value: T, defaultValue: D) {
     value ??= {} as T;
     for (const property in defaultValue) {
-      const result = defaultValue[property] as AllPartial<T[keyof T]>;
-      value[property as keyof T] ??= result as T[keyof T];
+      type K = Extract<keyof T, string>;
+      const result = defaultValue[property] as AllPartial<T[K]>;
+      value[property as K] ??= result as T[K];
     }
 
     return value as NonNullable<T & D>;
@@ -446,7 +447,7 @@ export class PgCommon {
    * @returns the object keys as an array
    */
   static keys<T extends Record<string, unknown>>(obj: T) {
-    return Object.keys(obj) as Array<keyof T>;
+    return Object.keys(obj) as Array<Extract<keyof T, string>>;
   }
 
   /**
@@ -456,7 +457,7 @@ export class PgCommon {
    * @returns the object entries as an array of [key, value] tuples
    */
   static entries<T extends Record<string, unknown>>(obj: T) {
-    return Object.entries(obj) as Array<[keyof T, ValueOf<T>]>;
+    return Object.entries(obj) as Array<[Extract<keyof T, string>, ValueOf<T>]>;
   }
 
   /**

--- a/client/src/utils/decorators/common.ts
+++ b/client/src/utils/decorators/common.ts
@@ -42,7 +42,7 @@ export type OnDidChangeDefault<T> = {
 
 /** Non-recursive `onDidChange${propertyName}` method types */
 export type OnDidChangeProperty<T> = {
-  [K in keyof T as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: OnDidChange<
+  [K in Extract<keyof T, string> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: OnDidChange<
     T[K]
   >;
 };

--- a/client/src/utils/decorators/common.ts
+++ b/client/src/utils/decorators/common.ts
@@ -1,5 +1,5 @@
 import { PgCommon } from "../common";
-import type { Accessor, Disposable, SyncOrAsync } from "../types";
+import type { Accessor, Disposable, StringKeys, SyncOrAsync } from "../types";
 
 /** Property names */
 export const PROPS = {
@@ -42,10 +42,9 @@ export type OnDidChangeDefault<T> = {
 
 /** Non-recursive `onDidChange${propertyName}` method types */
 export type OnDidChangeProperty<T> = {
-  [K in Extract<
-    keyof T,
-    string
-  > as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: OnDidChange<T[K]>;
+  [K in StringKeys<T> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: OnDidChange<
+    T[K]
+  >;
 };
 
 /** Actual type of the `onDidChange` property */

--- a/client/src/utils/decorators/common.ts
+++ b/client/src/utils/decorators/common.ts
@@ -42,9 +42,10 @@ export type OnDidChangeDefault<T> = {
 
 /** Non-recursive `onDidChange${propertyName}` method types */
 export type OnDidChangeProperty<T> = {
-  [K in Extract<keyof T, string> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: OnDidChange<
-    T[K]
-  >;
+  [K in Extract<
+    keyof T,
+    string
+  > as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: OnDidChange<T[K]>;
 };
 
 /** Actual type of the `onDidChange` property */

--- a/client/src/utils/decorators/common.ts
+++ b/client/src/utils/decorators/common.ts
@@ -1,5 +1,5 @@
 import { PgCommon } from "../common";
-import type { Accessor, Disposable, StringKeys, SyncOrAsync } from "../types";
+import type { Accessor, Disposable, KeyOf, SyncOrAsync } from "../types";
 
 /** Property names */
 export const PROPS = {
@@ -42,7 +42,7 @@ export type OnDidChangeDefault<T> = {
 
 /** Non-recursive `onDidChange${propertyName}` method types */
 export type OnDidChangeProperty<T> = {
-  [K in StringKeys<T> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: OnDidChange<
+  [K in KeyOf<T> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: OnDidChange<
     T[K]
   >;
 };

--- a/client/src/utils/decorators/updatable.ts
+++ b/client/src/utils/decorators/updatable.ts
@@ -12,7 +12,7 @@ export type Updatable<T> = {
 
 /** Recursive `onDidChange${propertyName}` method types */
 export type OnDidChangePropertyRecursive<T, U = FlattenObject<T>> = {
-  [K in keyof U as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: (
+  [K in Extract<keyof U, string> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: (
     cb: (value: U[K]) => void
   ) => Disposable;
 };
@@ -346,7 +346,9 @@ type JoinCapitalized<T extends string[]> = T extends [
 
 /** Map the property values to a union of tuples */
 type PropertiesToUnionOfTuples<T, Acc extends string[] = []> = {
-  [K in keyof T]: T[K] extends object
-    ? [[...Acc, K], T[K]] | PropertiesToUnionOfTuples<T[K], [...Acc, K]>
-    : [[...Acc, K], T[K]];
+  [K in keyof T]: K extends string
+    ? T[K] extends object
+      ? [[...Acc, K], T[K]] | PropertiesToUnionOfTuples<T[K], [...Acc, K]>
+      : [[...Acc, K], T[K]]
+    : never;
 }[keyof T];

--- a/client/src/utils/decorators/updatable.ts
+++ b/client/src/utils/decorators/updatable.ts
@@ -1,6 +1,6 @@
 import { PgCommon } from "../common";
 import { addInit, addOnDidChange, getChangePropName, PROPS } from "./common";
-import type { Disposable, StringKeys, SyncOrAsync } from "../types";
+import type { Disposable, KeyOf, SyncOrAsync } from "../types";
 
 /** Updatable decorator */
 export type Updatable<T> = {
@@ -12,7 +12,7 @@ export type Updatable<T> = {
 
 /** Recursive `onDidChange${propertyName}` method types */
 export type OnDidChangePropertyRecursive<T, U = FlattenObject<T>> = {
-  [K in StringKeys<U> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: (
+  [K in KeyOf<U> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: (
     cb: (value: U[K]) => void
   ) => Disposable;
 };

--- a/client/src/utils/decorators/updatable.ts
+++ b/client/src/utils/decorators/updatable.ts
@@ -12,7 +12,10 @@ export type Updatable<T> = {
 
 /** Recursive `onDidChange${propertyName}` method types */
 export type OnDidChangePropertyRecursive<T, U = FlattenObject<T>> = {
-  [K in Extract<keyof U, string> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: (
+  [K in Extract<
+    keyof U,
+    string
+  > as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: (
     cb: (value: U[K]) => void
   ) => Disposable;
 };

--- a/client/src/utils/decorators/updatable.ts
+++ b/client/src/utils/decorators/updatable.ts
@@ -346,7 +346,7 @@ type JoinCapitalized<T extends string[]> = T extends [
 
 /** Map the property values to a union of tuples */
 type PropertiesToUnionOfTuples<T, Acc extends string[] = []> = {
-  [K in keyof T]: K extends string
+  [K in keyof T]: K extends KeyOf<T>
     ? T[K] extends object
       ? [[...Acc, K], T[K]] | PropertiesToUnionOfTuples<T[K], [...Acc, K]>
       : [[...Acc, K], T[K]]

--- a/client/src/utils/decorators/updatable.ts
+++ b/client/src/utils/decorators/updatable.ts
@@ -1,6 +1,6 @@
 import { PgCommon } from "../common";
 import { addInit, addOnDidChange, getChangePropName, PROPS } from "./common";
-import type { Disposable, SyncOrAsync } from "../types";
+import type { Disposable, StringKeys, SyncOrAsync } from "../types";
 
 /** Updatable decorator */
 export type Updatable<T> = {
@@ -12,10 +12,7 @@ export type Updatable<T> = {
 
 /** Recursive `onDidChange${propertyName}` method types */
 export type OnDidChangePropertyRecursive<T, U = FlattenObject<T>> = {
-  [K in Extract<
-    keyof U,
-    string
-  > as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: (
+  [K in StringKeys<U> as `${typeof PROPS.ON_DID_CHANGE}${Capitalize<K>}`]: (
     cb: (value: U[K]) => void
   ) => Disposable;
 };

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -117,6 +117,9 @@ export type SyncOrAsync<T = unknown> = T | Promise<T>;
 /** A `Promise` or a callback that returns a `Promise` */
 export type Promisable<T> = Getable<SyncOrAsync<T>>;
 
+/** String-only keys of `T` */
+export type StringKeys<T> = Extract<keyof T, string>;
+
 /** Make every property (... | null) */
 export type Nullable<T> = {
   [K in keyof T]: T[K] | null;

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -1,3 +1,6 @@
+/** Get the keys of `T` (strings) */
+export type KeyOf<T> = Extract<keyof T, string>;
+
 /** Get value of the given object */
 export type ValueOf<T extends object> = T[keyof T];
 
@@ -116,9 +119,6 @@ export type SyncOrAsync<T = unknown> = T | Promise<T>;
 
 /** A `Promise` or a callback that returns a `Promise` */
 export type Promisable<T> = Getable<SyncOrAsync<T>>;
-
-/** String-only keys of `T` */
-export type KeyOf<T> = Extract<keyof T, string>;
 
 /** Make every property (... | null) */
 export type Nullable<T> = {

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -118,7 +118,7 @@ export type SyncOrAsync<T = unknown> = T | Promise<T>;
 export type Promisable<T> = Getable<SyncOrAsync<T>>;
 
 /** String-only keys of `T` */
-export type StringKeys<T> = Extract<keyof T, string>;
+export type KeyOf<T> = Extract<keyof T, string>;
 
 /** Make every property (... | null) */
 export type Nullable<T> = {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0", // Required for "keyofStringsOnly" which was deprecated in TS 5.0
     "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "5.0", // Required for "keyofStringsOnly" which was deprecated in TS 5.0
     "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
@@ -16,8 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "experimentalDecorators": true,
-    "keyofStringsOnly": true
+    "experimentalDecorators": true
   },
   "include": ["src"],
   "exclude": ["/**/*.raw.d.ts", "/**/declarations/packages/"]

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7238,9 +7238,9 @@ for-each@^0.3.3:
     is-callable "^1.1.3"
 
 fork-ts-checker-webpack-plugin@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.0.tgz#0282b335fa495a97e167f69018f566ea7d2a2b5e"
-  integrity sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz#eda2eff6e22476a2688d10661688c47f611b37f3"
+  integrity sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==
   dependencies:
     "@babel/code-frame" "^7.8.3"
     "@types/json-schema" "^7.0.5"
@@ -12917,10 +12917,10 @@ typescript-collections@^1.3.3:
   resolved "https://registry.yarnpkg.com/typescript-collections/-/typescript-collections-1.3.3.tgz#62d50d93c018c094d425eabee649f00ec5cc0fea"
   integrity sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ==
 
-typescript@=4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.0.4, typescript@=5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 u3@^0.1.1:
   version "0.1.1"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9799,10 +9799,10 @@ monaco-editor-webpack-plugin@^7.0.1:
   dependencies:
     loader-utils "^2.0.2"
 
-monaco-editor@=0.36.1:
-  version "0.36.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.36.1.tgz#aad528c815605307473a1634612946921d8079b5"
-  integrity sha512-/CaclMHKQ3A6rnzBzOADfwdSJ25BFoFT0Emxsc4zYVyav5SkK9iA6lEtIeuN/oRYbwPgviJT+t3l+sjFa28jYg==
+monaco-editor@=0.37.1:
+  version "0.37.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.37.1.tgz#d6f5ffb593e019e74e19bf8a2bdef5a691876f4e"
+  integrity sha512-jLXEEYSbqMkT/FuJLBZAVWGuhIb4JNwHE9kPTorAVmsdZ4UzHAfgWxLsVtD7pLRFaOwYPhNG9nUCpmFL1t/dIg==
 
 mri@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
Upgrades the TypeScript compiler from 4.9.5 to 5.0.4 and adds type checking and build verification scripts.


### Problem

`@solana/codecs-data-structures@2.0.0-rc.1` (transitive dependency via `@solana/web3.js`) uses `const` type parameters — a syntax introduced in TypeScript 5.0. The TS 4.9.5 compiler cannot parse these declarations, producing 160 errors across 4 files:

```
node_modules/@solana/codecs-data-structures/dist/types/discriminated-union.d.ts:75:54
error TS1139: Type parameter declaration expected.

export declare function getDiscriminatedUnionEncoder<const TVariants extends Variants<Encoder<any>>, ...
Found 160 errors in 4 files.
```

**To reproduce:**
1. Checkout `playground/master`
2. `cd client && yarn install`
3. `yarn exec tsc -- --noEmit`

### Solution

- Upgrade `typescript` from `=4.9.5` to `=5.0.4` with a `resolutions` entry to ensure a single version across the dependency tree
- Add `"ignoreDeprecations": "5.0"` to `tsconfig.json` — the project uses `keyofStringsOnly` (`keyof` in template literal types). That was deprecated in TS 5.0 and will be removed in TS 5.5
- Add `test` script (`tsc --noEmit` + `craco build`) to verify both type correctness and build compatibility with `react-scripts`
