### PR TITLE
Warn during deployments before reusing stale binary after a failed build

### DIFF
--- a/client/src/commands/build/build.ts
+++ b/client/src/commands/build/build.ts
@@ -22,7 +22,15 @@ export const build = createCmd({
 
     try {
       const result = await buildProgram();
-      PgProgramInfo.update({ idl: result.idl, uuid: result.uuid ?? undefined });
+      // Server only returns `uuid` on the first build of a session, so we
+      // can't use it as a success signal. Mirror the server's own check on
+      // `stderr` so deploy can warn before reusing a stale binary.
+      const failed = result.stderr.includes("error: could not compile");
+      PgProgramInfo.update({
+        idl: result.idl,
+        uuid: result.uuid ?? undefined,
+        lastBuildError: failed ? result.stderr : null,
+      });
       PgTerminal.println(improveOutput(result.stderr));
     } finally {
       PgGlobal.update({ buildLoading: false });

--- a/client/src/commands/build/build.ts
+++ b/client/src/commands/build/build.ts
@@ -29,7 +29,7 @@ export const build = createCmd({
       PgProgramInfo.update({
         idl: result.idl,
         uuid: result.uuid ?? undefined,
-        lastBuildError: failed ? result.stderr : null,
+        lastBuildFailed: failed,
       });
       PgTerminal.println(improveOutput(result.stderr));
     } finally {

--- a/client/src/commands/deploy/deploy.ts
+++ b/client/src/commands/deploy/deploy.ts
@@ -70,6 +70,24 @@ async function checkProgram() {
     await PgCommand.build.execute();
   }
 
+  // The server keeps the previous `solpg.so` after a failed compile, so /deploy
+  // would silently upload the stale binary. Make that explicit and let the user
+  // opt in. Only relevant when we'd actually use the server-cached binary.
+  if (
+    PgProgramInfo.lastBuildError &&
+    !PgProgramInfo.importedProgram?.buffer.length
+  ) {
+    PgTerminal.println(
+      "Warning: Your last build failed. Deploying now will upload the last successful build, not the current sources."
+    );
+    const term = await PgTerminal.get();
+    const proceed = await term.waitForInput(
+      "Deploy the previously built binary anyway?",
+      { confirm: true, default: "no" }
+    );
+    if (!proceed) throw new Error("Deployment cancelled: last build failed.");
+  }
+
   if (!PgProgramInfo.pk) {
     throw new Error(
       "Program ID not found. Go to 'Build & Deploy' tab and set the program ID."

--- a/client/src/commands/deploy/deploy.ts
+++ b/client/src/commands/deploy/deploy.ts
@@ -70,11 +70,11 @@ async function checkProgram() {
     await PgCommand.build.execute();
   }
 
-  // The server keeps the previous `solpg.so` after a failed compile, so /deploy
-  // would silently upload the stale binary. Make that explicit and let the user
-  // opt in. Only relevant when we'd actually use the server-cached binary.
+  // The server keeps the previous program binary after a failed compilation, so
+  // /deploy would silently return the stale binary. Ask the user about whether
+  // to proceed with the deployment using the server-cached binary.
   if (
-    PgProgramInfo.lastBuildError &&
+    PgProgramInfo.lastBuildFailed &&
     !PgProgramInfo.importedProgram?.buffer.length
   ) {
     PgTerminal.println(

--- a/client/src/utils/program-info.ts
+++ b/client/src/utils/program-info.ts
@@ -31,6 +31,8 @@ type ProgramInfo = Nullable<{
     buffer: Buffer;
     fileName: string;
   };
+  /** stderr from the last failed build; cleared on success. Persisted so a reload doesn't drop the warning. */
+  lastBuildError: string;
 }>;
 
 /** Serialized program info that's used in storage */
@@ -39,6 +41,7 @@ type SerializedProgramInfo = Nullable<{
   kp: Array<number>;
   customPk: string;
   idl: Idl;
+  lastBuildError: string;
 }>;
 
 const defaultState: ProgramInfo = {
@@ -47,6 +50,7 @@ const defaultState: ProgramInfo = {
   customPk: null,
   idl: null,
   importedProgram: null,
+  lastBuildError: null,
 };
 
 const storage = {
@@ -88,6 +92,7 @@ const storage = {
       idl: state.idl,
       kp: state.kp ? Array.from(state.kp.secretKey) : null,
       customPk: state.customPk?.toBase58() ?? null,
+      lastBuildError: state.lastBuildError,
     };
 
     await PgExplorer.fs.writeFile(this.PATH, JSON.stringify(serializedState));

--- a/client/src/utils/program-info.ts
+++ b/client/src/utils/program-info.ts
@@ -31,7 +31,7 @@ type ProgramInfo = Nullable<{
     buffer: Buffer;
     fileName: string;
   };
-  /** Whether the last build failed; cleared on success. Persisted so a reload doesn't drop the warning. */
+  /** Whether the last build failed */
   lastBuildFailed: boolean;
 }>;
 

--- a/client/src/utils/program-info.ts
+++ b/client/src/utils/program-info.ts
@@ -31,8 +31,8 @@ type ProgramInfo = Nullable<{
     buffer: Buffer;
     fileName: string;
   };
-  /** stderr from the last failed build; cleared on success. Persisted so a reload doesn't drop the warning. */
-  lastBuildError: string;
+  /** Whether the last build failed; cleared on success. Persisted so a reload doesn't drop the warning. */
+  lastBuildFailed: boolean;
 }>;
 
 /** Serialized program info that's used in storage */
@@ -41,7 +41,7 @@ type SerializedProgramInfo = Nullable<{
   kp: Array<number>;
   customPk: string;
   idl: Idl;
-  lastBuildError: string;
+  lastBuildFailed: boolean;
 }>;
 
 const defaultState: ProgramInfo = {
@@ -50,7 +50,7 @@ const defaultState: ProgramInfo = {
   customPk: null,
   idl: null,
   importedProgram: null,
-  lastBuildError: null,
+  lastBuildFailed: null,
 };
 
 const storage = {
@@ -92,7 +92,7 @@ const storage = {
       idl: state.idl,
       kp: state.kp ? Array.from(state.kp.secretKey) : null,
       customPk: state.customPk?.toBase58() ?? null,
-      lastBuildError: state.lastBuildError,
+      lastBuildFailed: state.lastBuildFailed,
     };
 
     await PgExplorer.fs.writeFile(this.PATH, JSON.stringify(serializedState));

--- a/client/src/utils/terminal/terminal.ts
+++ b/client/src/utils/terminal/terminal.ts
@@ -451,7 +451,9 @@ export class PgTerm {
         : number
       : string
   > {
-    // Avoid `this.focus()` here: its `scrollToCursor()` desyncs the DOM scroll from xterm's state and leaves the next render at the wrong position.
+    // Avoid `this.focus()` here because it calls `scrollToCursor`, which may
+    // desync the DOM scroll from `xterm`'s state and leave the next render at
+    // the wrong position.
     this._xterm.focus();
     this.scrollToBottom();
 

--- a/client/src/utils/terminal/terminal.ts
+++ b/client/src/utils/terminal/terminal.ts
@@ -331,6 +331,11 @@ export class PgTerm {
     this.scrollToCursor();
   }
 
+  /** Focus only; `scrollToCursor()`'s formula desyncs the DOM scroll from xterm's state and leaves the next render at the wrong position. */
+  focusOnly() {
+    this._xterm.focus();
+  }
+
   /** Scroll terminal to wherever the cursor currently is. */
   scrollToCursor() {
     const scrollableEl = document
@@ -451,7 +456,8 @@ export class PgTerm {
         : number
       : string
   > {
-    this.focus();
+    this.focusOnly();
+    this.scrollToBottom();
 
     let convertedMsg = msg;
     const disposables = [];

--- a/client/src/utils/terminal/terminal.ts
+++ b/client/src/utils/terminal/terminal.ts
@@ -331,11 +331,6 @@ export class PgTerm {
     this.scrollToCursor();
   }
 
-  /** Focus only; `scrollToCursor()`'s formula desyncs the DOM scroll from xterm's state and leaves the next render at the wrong position. */
-  focusOnly() {
-    this._xterm.focus();
-  }
-
   /** Scroll terminal to wherever the cursor currently is. */
   scrollToCursor() {
     const scrollableEl = document
@@ -456,7 +451,8 @@ export class PgTerm {
         : number
       : string
   > {
-    this.focusOnly();
+    // Avoid `this.focus()` here: its `scrollToCursor()` desyncs the DOM scroll from xterm's state and leaves the next render at the wrong position.
+    this._xterm.focus();
     this.scrollToBottom();
 
     let convertedMsg = msg;


### PR DESCRIPTION
## Surface "deploy after failed build" client-side instead of mutating server state

<img width="971" height="280" alt="image" src="https://github.com/user-attachments/assets/4c4371b6-d6a0-4f85-8e06-8dfd74cf3e58" />


### Background

After a successful build, `programs/<uuid>/solpg.so` sits on disk on the build server. If the user then submits a build that **fails to compile**, `program::build` early-returns without touching the previous artifact, and `GET /deploy/:uuid` returns the previous successful binary — the playground silently deploys stale code.

## Why not fix this server-side

An earlier version of this branch deleted `solpg.so` before each `cargo-build-sbf` invocation. After review feedback from @acheroncrypto the direction changed, and the server-side work has been dropped from this PR:

- "Leave the previous artifact alone on compile failure" is what `cargo`, `solana-program`, and `anchor` do locally. A user running `anchor build` and hitting a compile error keeps the prior `target/deploy/*.so` on disk.
- The playground is gaining more frameworks and versions. Each ships its own build CLI with its own assumptions about artifact lifecycle. The less the server overrides those, the fewer surprises across frameworks.
- The user-facing problem isn't the file on disk — it's the **silent deploy**. The user doesn't know they're about to upload an old binary. That's a UX concern, not a build-server concern.

This PR's diff against `master` is therefore purely client-side; the server tree is untouched.

## What this PR does

1. **Tracks the last build error on the client.** `PgProgramInfo` gains a persisted `lastBuildError: string | null` field, carried in both `ProgramInfo` (in-memory) and `SerializedProgramInfo` (storage). The build command sets it to `result.stderr` when stderr matches the server's own compile-failure check — `stderr.includes("error: could not compile")`, mirroring `server/src/program.rs` — and clears it back to `null` on the next successful build. The check is intentionally not gated on `result.uuid`: the server only returns a `uuid` on the **first** build per client session and `null` thereafter, regardless of success, so it can't double as a success signal. The flag is persisted because the server's cached `solpg.so` survives page reloads — the warning signal has to survive with it.

2. **Warns and asks for confirmation on deploy.** In `checkProgram` (the deploy command's pre-check), if `lastBuildError` is set and there's no user-imported `.so` to use instead, the terminal prints `Warning: Your last build failed. Deploying now will upload the last successful build, not the current sources.`, then prompts `Deploy the previously built binary anyway? [yes/no]` with `default: "no"`. Declining throws `Deployment cancelled: last build failed.` so the existing `try/finally` resets deploy state cleanly.

3. **Ensures the new prompt is visible.** `waitForUserInput` in `terminal.ts` now calls `scrollToBottom()` after `focus()`. `focus()` alone only scrolls to the cursor; if the user had scrolled up while reading the failed-build output, the new prompt would land off-screen.

## Behavior matrix

| State | Behavior on deploy |
|---|---|
| Last build succeeded (or no prior failure recorded) | Deploys, no prompt. |
| Last build failed, no imported `.so` | Warning + `[yes/no]` confirmation, `default: "no"`. Decline ⇒ deploy aborts. Confirm ⇒ deploys the server-cached binary — same end result as before this PR, but now opt-in. |
| Last build failed, imported `.so` present | Deploys the imported binary, no prompt — the server-cached binary isn't read. |