### PR TITLE
fix(client): add noImplicitReturns to the config

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -97,7 +97,7 @@
     "generate-tutorials": "node scripts/generate-tutorials.mjs",
     "sync-readme": "node scripts/sync-readme.mjs",
     "test": "yarn test-types && yarn build",
-    "test-types": "tsc --noEmit"
+    "test-types": "yarn generate && tsc --noEmit"
   },
   "eslintConfig": {
     "extends": [

--- a/client/src/components/Editor/Home/Home.tsx
+++ b/client/src/components/Editor/Home/Home.tsx
@@ -197,7 +197,7 @@ const getSrc = (url: string) => {
   if (url.includes("youtube.com")) src = "youtube.png";
   else if (url.includes("dev.to")) src = "devto.png";
 
-  if (src) return "/icons/platforms/" + src;
+  return src ? "/icons/platforms/" + src : undefined;
 };
 
 const TutorialCard = styled(Card)`

--- a/client/src/components/Editor/Monaco/Monaco.tsx
+++ b/client/src/components/Editor/Monaco/Monaco.tsx
@@ -229,6 +229,7 @@ const Monaco = () => {
   // Dispose editor
   useEffect(() => {
     if (editor) return () => editor.dispose();
+    return;
   }, [editor]);
 
   // Set editor state

--- a/client/src/components/FilterGroups/FilterGroups.tsx
+++ b/client/src/components/FilterGroups/FilterGroups.tsx
@@ -131,6 +131,7 @@ const StyledTag = styled(Tag)`
         box-shadow: none;
       `;
     }
+    return undefined;
   }}
 `;
 

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -563,6 +563,7 @@ export class PgCommon {
     if (userAgent.includes("win")) return "Windows";
     if (userAgent.includes("mac")) return "MacOS";
     if (userAgent.includes("linux")) return "Linux";
+    return undefined;
   }
 
   /**
@@ -587,6 +588,7 @@ export class PgCommon {
     if ((navigator as any).brave) return "Brave";
     if (navigator.userAgent.includes("Chrome")) return "Chrome";
     if (navigator.userAgent.includes("Firefox")) return "Firefox";
+    return undefined;
   }
 
   /**

--- a/client/src/utils/explorer/explorer.ts
+++ b/client/src/utils/explorer/explorer.ts
@@ -745,6 +745,7 @@ export class PgExplorer {
     if (this.currentFilePath) {
       return PgLanguage.getFromPath(this.currentFilePath);
     }
+    return undefined;
   }
 
   /**
@@ -756,6 +757,7 @@ export class PgExplorer {
     if (this.currentFilePath) {
       return PgLanguage.getIsPathJsLike(this.currentFilePath);
     }
+    return undefined;
   }
 
   /**
@@ -1355,6 +1357,7 @@ export class PgExplorer {
   static getItemTypeFromEl(el: HTMLDivElement) {
     const path = PgExplorer.getItemPathFromEl(el);
     if (path) return PgExplorer.getItemTypeFromPath(path);
+    return undefined;
   }
 
   /**
@@ -1402,6 +1405,7 @@ export class PgExplorer {
         el.parentElement!.previousElementSibling as HTMLDivElement
       );
     }
+    return undefined;
   }
 
   /**
@@ -1444,6 +1448,7 @@ export class PgExplorer {
       PgView.classNames.CTX_SELECTED
     );
     if (ctxSelectedEls.length) return ctxSelectedEls[0];
+    return undefined;
   }
 
   /** Set the selected context element. */

--- a/client/src/utils/framework.ts
+++ b/client/src/utils/framework.ts
@@ -111,6 +111,7 @@ export class PgFramework {
       const isCurrent = await framework.getIsCurrent(files);
       if (isCurrent) return framework;
     }
+    return undefined;
   }
 
   /**

--- a/client/src/utils/playnet/playnet.ts
+++ b/client/src/utils/playnet/playnet.ts
@@ -124,6 +124,7 @@ export class PgPlaynet {
       return await PgExplorer.fs.readToString(this._PATHS.SAVE_DATA);
     } catch (e: any) {
       console.log("Couldn't get Playnet data:", e.message);
+      return undefined;
     }
   }
 }

--- a/client/src/utils/router.ts
+++ b/client/src/utils/router.ts
@@ -229,6 +229,7 @@ export class PgRouter {
           index + endIndex + 1
         );
       }
+      return undefined;
     };
 
     recursivelyMapValues(path);

--- a/client/src/utils/terminal/history.ts
+++ b/client/src/utils/terminal/history.ts
@@ -57,6 +57,7 @@ export class PgHistory {
     const index = Math.max(0, this._cursor - 1);
     this._cursor = index;
     if (this._entries.length > index) return this._entries[index];
+    return undefined;
   }
 
   /**
@@ -68,5 +69,6 @@ export class PgHistory {
     const index = Math.min(this._entries.length, this._cursor + 1);
     this._cursor = index;
     if (this._entries.length >= index) return this._entries[index];
+    return undefined;
   }
 }

--- a/client/src/utils/terminal/terminal.ts
+++ b/client/src/utils/terminal/terminal.ts
@@ -293,7 +293,7 @@ export class PgTerm {
     this._xterm.onKey((ev) => {
       if (ev.key === " ") {
         ev.domEvent.preventDefault();
-        return false;
+        return;
       }
     });
 

--- a/client/src/utils/terminal/tty.ts
+++ b/client/src/utils/terminal/tty.ts
@@ -85,6 +85,7 @@ export class PgTty {
         currentLineStr.startsWith(this._continuationPromptPrefix)
       );
     }
+    return false;
   }
 
   /**

--- a/client/src/utils/tx.ts
+++ b/client/src/utils/tx.ts
@@ -129,6 +129,7 @@ export class PgTx {
       opts?.commitment
     );
     if (result?.value.err) return { err: result.value.err };
+    return undefined;
   }
 
   /**

--- a/client/src/utils/wallet/wallet.ts
+++ b/client/src/utils/wallet/wallet.ts
@@ -299,6 +299,7 @@ class _PgWallet {
           return keypair;
         } catch (err: any) {
           console.log(err.message);
+          return undefined;
         }
       },
       { accept: ".json" }

--- a/client/src/views/sidebar/build-deploy/Component/Deploy.tsx
+++ b/client/src/views/sidebar/build-deploy/Component/Deploy.tsx
@@ -54,7 +54,8 @@ const Deploy = () => {
             // state has to be handled outside of the command because the deploy
             // command is waiting for user input and re-running the command here
             // would overwrite the user input.
-            return PgCommand.deploy.execute();
+            PgCommand.deploy.execute();
+            break;
 
           case "loading":
             PgGlobal.update({ deployState: "paused" });

--- a/client/src/views/sidebar/build-deploy/Component/ProgramSettings/IDL.tsx
+++ b/client/src/views/sidebar/build-deploy/Component/ProgramSettings/IDL.tsx
@@ -85,6 +85,8 @@ const InitOrUpgrade = () => {
       case InitOrUpgradeState.CAN_UPGRADE:
       case InitOrUpgradeState.INCORRECT_AUTHORITY:
         return "Upgrade";
+      default:
+        return undefined;
     }
   }, [state]);
 

--- a/client/src/views/sidebar/explorer/Component/Workspaces.tsx
+++ b/client/src/views/sidebar/explorer/Component/Workspaces.tsx
@@ -114,6 +114,7 @@ const WorkspaceSelect = () => {
       );
       if (val) return val;
     }
+    return undefined;
   }, [explorer.currentWorkspaceName, options]);
 
   return (

--- a/client/src/views/sidebar/test/Component/Instruction/Instruction.tsx
+++ b/client/src/views/sidebar/test/Component/Instruction/Instruction.tsx
@@ -107,6 +107,7 @@ const Instruction: FC<InstructionProps> = ({ index, idlInstruction }) => {
           )}.`,
           { noColor: true }
         );
+        return undefined;
       } catch (e: any) {
         if (e.message) {
           const ERRORS = [

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
PR adds `noImplicitReturns` into tsconfig to be in sync with the config for VSCode and has better rules in general.