### PR TITLE
fix(server): clean up env variables to not expose them within builder

### DIFF
--- a/server/src/program.rs
+++ b/server/src/program.rs
@@ -16,18 +16,14 @@ const MAX_FILE_AMOUNT: usize = 64;
 const MAX_PATH_LENGTH: usize = 128;
 
 /// Apply a clean environment containing only the toolchain locator vars,
-/// derived from `$HOME` so we don't assume a specific username or container layout.
+/// inherited from the parent process so we don't impose any OS-specific layout.
 fn apply_build_env(cmd: &mut Command) -> &mut Command {
-    let home = std::env::var("HOME").expect("HOME must be set for the build subprocess");
-    let build_path = format!(
-        "{home}/.local/share/solana/install/active_release/bin:{home}/.cargo/bin:\
-         /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-    );
-    cmd.env_clear()
-        .env("PATH", build_path)
-        .env("HOME", &home)
-        .env("CARGO_HOME", format!("{home}/.cargo"))
-        .env("RUSTUP_HOME", format!("{home}/.rustup"));
+    cmd.env_clear();
+    for key in ["PATH", "HOME", "CARGO_HOME", "RUSTUP_HOME"] {
+        if let Ok(val) = std::env::var(key) {
+            cmd.env(key, val);
+        }
+    }
     cmd
 }
 

--- a/server/src/program.rs
+++ b/server/src/program.rs
@@ -15,16 +15,20 @@ const MAX_FILE_AMOUNT: usize = 64;
 /// Maximum length of the file paths to pass to the [`build`] function.
 const MAX_PATH_LENGTH: usize = 128;
 
-/// PATH for the build subprocess.
-const BUILD_PATH: &str = "/home/solpg/.local/share/solana/install/active_release/bin:/home/solpg/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-
-/// Apply a clean environment containing only the toolchain locator vars.
+/// Apply a clean environment containing only the toolchain locator vars,
+/// derived from `$HOME` so we don't assume a specific username or container layout.
 fn apply_build_env(cmd: &mut Command) -> &mut Command {
+    let home = std::env::var("HOME").expect("HOME must be set for the build subprocess");
+    let build_path = format!(
+        "{home}/.local/share/solana/install/active_release/bin:{home}/.cargo/bin:\
+         /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    );
     cmd.env_clear()
-        .env("PATH", BUILD_PATH)
-        .env("HOME", "/home/solpg")
-        .env("CARGO_HOME", "/home/solpg/.cargo")
-        .env("RUSTUP_HOME", "/home/solpg/.rustup")
+        .env("PATH", build_path)
+        .env("HOME", &home)
+        .env("CARGO_HOME", format!("{home}/.cargo"))
+        .env("RUSTUP_HOME", format!("{home}/.rustup"));
+    cmd
 }
 
 /// A vector of [Path, Content]

--- a/server/src/program.rs
+++ b/server/src/program.rs
@@ -15,6 +15,18 @@ const MAX_FILE_AMOUNT: usize = 64;
 /// Maximum length of the file paths to pass to the [`build`] function.
 const MAX_PATH_LENGTH: usize = 128;
 
+/// PATH for the build subprocess.
+const BUILD_PATH: &str = "/home/solpg/.local/share/solana/install/active_release/bin:/home/solpg/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+/// Apply a clean environment containing only the toolchain locator vars.
+fn apply_build_env(cmd: &mut Command) -> &mut Command {
+    cmd.env_clear()
+        .env("PATH", BUILD_PATH)
+        .env("HOME", "/home/solpg")
+        .env("CARGO_HOME", "/home/solpg/.cargo")
+        .env("RUSTUP_HOME", "/home/solpg/.rustup")
+}
+
 /// A vector of [Path, Content]
 pub type Files = Vec<[String; 2]>;
 
@@ -109,7 +121,8 @@ pub fn build(
     )?;
 
     // Build the program
-    let output = Command::new("cargo-build-sbf")
+    let mut cmd = Command::new("cargo-build-sbf");
+    let output = apply_build_env(&mut cmd)
         .arg("--manifest-path")
         .arg(manifest_path)
         .arg("--sbf-out-dir")

--- a/server/src/program.rs
+++ b/server/src/program.rs
@@ -111,16 +111,12 @@ pub fn build(
     // Build the program with a clean env, inheriting only toolchain locator vars from the parent.
     let output = Command::new("cargo-build-sbf")
         .env_clear()
-        .envs(
-            ["PATH", "HOME"]
-                .into_iter()
-                .filter_map(|key| {
-                    std::env::var(key)
-                        .inspect_err(|e| warn!("Failed to get env variable: `{key}`: {e}"))
-                        .ok()
-                        .map(|value| (key, value))
-                }),
-        )
+        .envs(["PATH", "HOME"].into_iter().filter_map(|key| {
+            std::env::var(key)
+                .inspect_err(|e| warn!("Failed to get env variable: `{key}`: {e}"))
+                .ok()
+                .map(|value| (key, value))
+        }))
         .arg("--manifest-path")
         .arg(manifest_path)
         .arg("--sbf-out-dir")

--- a/server/src/program.rs
+++ b/server/src/program.rs
@@ -4,7 +4,7 @@ use anchor_syn::idl::{parse::file::parse as parse_idl, types::Idl};
 use anyhow::anyhow;
 use regex::Regex;
 
-use crate::log::info;
+use crate::log::{info, warn};
 
 /// Directory name of where the programs are stored
 const PROGRAMS_DIR: &str = "programs";
@@ -14,18 +14,6 @@ const MAX_FILE_AMOUNT: usize = 64;
 
 /// Maximum length of the file paths to pass to the [`build`] function.
 const MAX_PATH_LENGTH: usize = 128;
-
-/// Apply a clean environment containing only the toolchain locator vars,
-/// inherited from the parent process so we don't impose any OS-specific layout.
-fn apply_build_env(cmd: &mut Command) -> &mut Command {
-    cmd.env_clear();
-    for key in ["PATH", "HOME", "CARGO_HOME", "RUSTUP_HOME"] {
-        if let Ok(val) = std::env::var(key) {
-            cmd.env(key, val);
-        }
-    }
-    cmd
-}
 
 /// A vector of [Path, Content]
 pub type Files = Vec<[String; 2]>;
@@ -120,9 +108,19 @@ pub fn build(
         MANIFEST.replacen("default", &format!("../{program_name}"), 1),
     )?;
 
-    // Build the program
-    let mut cmd = Command::new("cargo-build-sbf");
-    let output = apply_build_env(&mut cmd)
+    // Build the program with a clean env, inheriting only toolchain locator vars from the parent.
+    let output = Command::new("cargo-build-sbf")
+        .env_clear()
+        .envs(
+            ["PATH", "HOME"]
+                .into_iter()
+                .filter_map(|key| {
+                    std::env::var(key)
+                        .inspect_err(|e| warn!("Failed to get env variable: `{key}`: {e}"))
+                        .ok()
+                        .map(|value| (key, value))
+                }),
+        )
         .arg("--manifest-path")
         .arg(manifest_path)
         .arg("--sbf-out-dir")


### PR DESCRIPTION
**Context.** The `/build` endpoint spawns `cargo-build-sbf` as a child process at `server/src/program.rs:124` to compile user-submitted Solana programs. Until now the child inherited the full server process env, which on a deployed container includes every `PG_*` config var (e.g. `PG_DB_URI`, `PG_CLIENT_URLS`) plus anything the host passes through.

**Problem.** Any env var present in the server process is visible to user-submitted code at compile time via the `env!` / `option_env!` macros. A submitted program can read e.g. `PG_DB_URI` and bake its value into the compiled artifact, then exfiltrate it through the `stderr` or `idl` fields returned in the build response.

**Why to solve.** The build endpoint accepts untrusted source from the public client. Sensitive deployment configuration (DB credentials, internal URLs, anything an operator puts in env) leaking into compiled programs is a credential-disclosure risk for every operator running the server. The leak is silent — nothing in the current code path warns about it.

**Solution.** Introduce `apply_build_env` at `server/src/program.rs:22` that calls `Command::env_clear()` and then re-injects only the four toolchain-locator vars `cargo-build-sbf` actually needs: `PATH`, `HOME`, `CARGO_HOME`, `RUSTUP_HOME`. Apply at the single subprocess spawn site — a static audit confirmed the server crate has exactly one process-spawn call.
Verified e2e on a docker-compose dev stack: with `PG_CANARY=should-not-leak` set in the server container env, a submitted program containing `env!("PG_CANARY")` fails to compile with `environment variable PG_CANARY not defined`, while `env!("CARGO_HOME")` compiles cleanly.
