### PR TITLE
fix(editor): enable fixedOverflowWidgets in Monaco editor (closes #176)

### DIFF
--- a/client/src/components/Editor/Monaco/Monaco.tsx
+++ b/client/src/components/Editor/Monaco/Monaco.tsx
@@ -250,6 +250,11 @@ const Monaco = () => {
       monaco.editor.create(monacoRef.current, {
         automaticLayout: true,
         fontLigatures: true,
+        // Render overflow widgets (context menu, find/replace, suggest widget,
+        // hover tooltips) as position:fixed elements appended to document.body
+        // so they aren't clipped by ancestor overflow:auto/hidden containers.
+        // Fixes #176 where editor popups appeared below other page elements.
+        fixedOverflowWidgets: true,
       })
     );
   }, [editor, isThemeSet]);


### PR DESCRIPTION
## What
Enables `fixedOverflowWidgets: true` in the Monaco editor configuration so editor pop elements (context menus, find/replace, suggest widget, hover tooltips) render above all other page content.

## Why
Closes #176

Monaco's overflow widgets are rendered as children of the editor's DOM node by default. When the editor sits inside an ancestor with `overflow: auto` (which our Editor `Wrapper` uses for scrollbars — see `client/src/components/Editor/Editor.tsx:48`), those widgets get clipped or hidden beneath sibling stacking contexts.

## Change
Single option addition in `client/src/components/Editor/Monaco/Monaco.tsx` (line 250):

```diff
   monaco.editor.create(monacoRef.current, {
     automaticLayout: true,
     fontLigatures: true,
+    // Render overflow widgets (context menu, find/replace, suggest widget,
+    // hover tooltips) as position:fixed elements appended to document.body
+    // so they aren't clipped by ancestor overflow:auto/hidden containers.
+    // Fixes #176 where editor popups appeared below other page elements.
+    fixedOverflowWidgets: true,
   })
```

## How it works
`fixedOverflowWidgets: true` tells Monaco to render its overflow widgets as `position: fixed` elements appended directly to `document.body`. This:
1. Escapes any ancestor containing block (overflow:auto/hidden, transform, filter, will-change)
2. Sits above all page content by Monaco's own z-index defaults
3. Is the official Monaco-recommended fix for this scenario

## Tested
- Right-click context menu in editor → now appears above all panels/modals
- Find/replace dialog (`Ctrl+F`) → anchored to viewport, not editor
- Suggest widget (autocomplete) → no longer clipped at editor bottom
- Hover tooltips → render above editor boundary

## Docs reference
`fixedOverflowWidgets` documented at:
https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html#fixedOverflowWidgets

Default value is `false` to maintain compatibility with iframe-embedded scenarios, but the standalone web app use case (which Solana Playground is) is the recommended-on case per Monaco's docs.

## Checklist
- [x] One-line behavior change + 5 lines of comment
- [x] No code refactor
- [x] No test changes needed (visual fix)
- [x] Closes open issue #176
