### PR TITLE
fix(server): use directory destination for multi-source COPY in Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -30,7 +30,8 @@ COPY rust-toolchain.toml .
 RUN cargo --version
 
 # Cache deps
-COPY Cargo.* .
+# Trailing slash required: Cloud Build's legacy builder rejects multi-source COPY into "."
+COPY Cargo.* ./
 RUN mkdir src
 RUN echo "fn main() {}" > src/main.rs
 RUN cargo build --release


### PR DESCRIPTION
**Context.** The server image (`server/Dockerfile`) builds locally and in any BuildKit-based environment, but the App Engine deploy pipeline builds it with Cloud Build's legacy Docker builder (`gcr.io/cloud-builders/docker`, no BuildKit).

**Problem.** The dependency-caching instruction `COPY Cargo.* .` (`server/Dockerfile:33`) has two sources (`Cargo.toml`, `Cargo.lock`) and a destination without a trailing slash. The legacy builder enforces the old multi-source rule and fails with *"When using COPY with more than one source file, the destination must be a directory and end with a /"*; the follow-up `INVALID_ARGUMENT ... image was either not found, or is not in Docker V2 format` deploy error is just the downstream consequence of the image never being built. BuildKit accepts `.`, which is why the problem never surfaced outside the pipeline.

**Why to solve.** Every server deploy through the CICD workflow fails at the remote build step, so no new version can reach App Engine until this lands.

**Potential Solution.** Change the destination to `./` (`COPY Cargo.* ./`) and keep a one-line comment explaining the trailing slash so it doesn't get reverted. The other `COPY` instructions are single-source and unaffected. This is what the PR does.