### PR TITLE
fix(server): pre-create workdir with non-root owner for Cloud Build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,6 +23,12 @@ ENV PATH="${HOME}/.cargo/bin:${PATH}"
 ############################## BUILD SERVER BINARY #############################
 FROM rust AS build
 
+ARG USER=solpg
+
+# Cloud Build's legacy builder creates WORKDIR as root even under USER
+USER root
+RUN mkdir /build && chown ${USER}:${USER} /build
+USER ${USER}
 WORKDIR /build
 
 # Cache toolchain


### PR DESCRIPTION
**Context.** The server image (`server/Dockerfile`) builds locally and in any BuildKit-based environment, but the App Engine deploy pipeline builds it with Cloud Build's legacy Docker builder (`gcr.io/cloud-builders/docker`, no BuildKit). The `build` stage runs as the non-root `solpg` user inherited from the base stage.

**Problem.** `WORKDIR /build` behaves differently across builders: BuildKit creates the directory owned by the active `USER`, while the legacy builder always creates it owned by `root`. On Cloud Build the stage therefore runs as `solpg` inside a root-owned `/build`, and the first write — `RUN mkdir src` (`server/Dockerfile:41`) — fails with *"mkdir: cannot create directory 'src': Permission denied"*. The follow-up `INVALID_ARGUMENT ... image was either not found, or is not in Docker V2 format` deploy error is just the downstream consequence of the image never being built. Same failure class as #461: semantics that differ between BuildKit and the legacy builder never surface outside the pipeline.

**Why to solve.** Every server deploy through the CICD workflow fails at the remote build step, so no new version can reach App Engine until this lands.

**Potential Solution.** Pre-create the workdir with the correct owner before switching back to the non-root user: `USER root; RUN mkdir /build && chown ${USER}:${USER} /build; USER ${USER}` ahead of `WORKDIR /build`, with a one-line comment explaining why. Verified with a full legacy-builder build (`DOCKER_BUILDKIT=0`) locally: the previously failing step and both cargo builds pass; ownership propagation through `COPY --from=build` plus the trailing `chmod 700` was confirmed safe on both builders with a minimal two-stage test. This is what the PR does.
