### PR TITLE
chore(CI): raise App Engine Cloud Build timeout so the server image can finish building

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Deploy to App Engine with specific version (no promote)
         working-directory: server
         run: |
+          # Rust release build alone is ~6m; full image build runs ~10.5m, past
+          # the 600s Cloud Build default. Raise the cap so the image can be pushed.
+          gcloud config set app/cloud_build_timeout 1800
           gcloud app deploy app.yaml \
             --version=${{ needs.resolve_version.outputs.version_tag }} \
             --no-promote \


### PR DESCRIPTION
**Context.** The server image (`server/Dockerfile`) is built for App Engine Flex by Cloud Build, which has a default build timeout of 600s (10 minutes). The image compiles the server in release mode, installs the Rust and Solana toolchains, and runs `cargo-build-sbf` on the default program.

**Problem.** The full build runs ~10m28s (the Rust release compile alone is 6m01s), so it crosses the 600s Cloud Build cap. Cloud Build aborts the build with `TIMEOUT` / `context deadline exceeded` before the image is pushed. The deploy then fails with `INVALID_ARGUMENT ... image was either not found, or is not in Docker V2 format` — a misleading downstream error: App Engine only consumes the image, and the tag it tries to resolve was never populated because the build that should have pushed it was killed.

**Why to solve.** Every server deploy through the CICD workflow fails at the remote build step, so no new version can reach App Engine until the build is allowed to finish.

**Potential Solution.** Set `gcloud config set app/cloud_build_timeout 1800` in the deploy step before `gcloud app deploy`, giving the build 30 minutes — comfortable headroom over the current ~10.5m. This is what the PR does. Layer caching to shorten the build itself (deps recompile from scratch on every run because Cloud Build keeps no layer cache) is left as separate follow-up work.
