### PR TITLE
Update outdated and moved links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solana Playground
 
-[SolPg](https://beta.solpg.io) allows you to quickly develop, deploy and test [Solana](https://docs.solana.com/introduction) programs(smart contracts) from browsers.
+[SolPg](https://beta.solpg.io) allows you to quickly develop, deploy and test [Solana](https://solana.com/docs/intro/quick-start) programs(smart contracts) from browsers.
 
 ## Supported crates
 

--- a/client/src/commands/sugar/commands/create-config/create-config.ts
+++ b/client/src/commands/sugar/commands/create-config/create-config.ts
@@ -17,7 +17,7 @@ export const processCreateConfig = async () => {
   );
   term.println(
     `  -> ${PgTerminal.underline(
-      "https://docs.metaplex.com/tools/sugar/configuration"
+      "https://www.metaplex.com/docs/smart-contracts/candy-machine/sugar/configuration"
     )}\n`
   );
 

--- a/client/src/commands/sugar/commands/validate/validate.ts
+++ b/client/src/commands/sugar/commands/validate/validate.ts
@@ -49,7 +49,7 @@ export const processValidate = async (
       term.println(
         PgTerminal.italic(
           [
-            "Check https://docs.metaplex.com/developer-tools/sugar/guides/preparing-assets for",
+            "Check https://www.metaplex.com/docs/smart-contracts/candy-machine/sugar/getting-started for",
             "the collection file requirements if you want a collection to be set automatically.",
           ].join(" ")
         )

--- a/client/src/components/Editor/Home/resources.ts
+++ b/client/src/components/Editor/Home/resources.ts
@@ -13,21 +13,21 @@ export const RESOURCES: ResourceProps[] = [
     name: "Cookbook",
     description:
       "Detailed explanations and guides for building applications on Solana.",
-    url: "https://solanacookbook.com/",
+    url: "https://solana.com/developers/cookbook",
     icon: "https://solanacookbook.com/solana_cookbook_darkmode.svg",
   },
   {
-    name: "SolDev",
+    name: "Developer Courses",
     description:
-      "Solana content aggregator with easy discoverability for all your development needs.",
-    url: "https://soldev.app/",
+      "Structured courses covering Solana development fundamentals and beyond.",
+    url: "https://github.com/solana-foundation/developer-content/tree/main/content/courses",
     icon: ROOT_DIR + "soldev.png",
   },
   {
     name: "Metaplex Docs",
     description:
       "Documentation for understanding how to work with NFTs on Solana using the Metaplex Standards.",
-    url: "https://developers.metaplex.com/",
+    url: "https://www.metaplex.com/docs/",
     icon: ROOT_DIR + "metaplex.png",
   },
 ];

--- a/client/src/components/Wallet/Transactions.tsx
+++ b/client/src/components/Wallet/Transactions.tsx
@@ -169,7 +169,7 @@ const Tx: FC<PgWeb3.ConfirmedSignatureInfo> = ({
   // `hover` state inconsistent i.e. `hover === true` when the pointer is not on
   // the element. This `useEffect` fixes the mentioned inconsistency.
   //
-  // https://github.com/facebook/react/issues/4492
+  // https://github.com/react/react/issues/4492
   useEffect(() => {
     if (!hover) return;
 

--- a/client/src/effects/connection/Local/steps.md
+++ b/client/src/effects/connection/Local/steps.md
@@ -2,7 +2,7 @@
 
 <OS_INSTALLATION>
 
-[Other installation methods](https://docs.solana.com/cli/install-solana-cli-tools)
+[Other installation methods](https://solana.com/docs/intro/installation)
 
 **2. Start a local test validator**
 

--- a/client/src/frameworks/anchor/anchor.ts
+++ b/client/src/frameworks/anchor/anchor.ts
@@ -10,7 +10,7 @@ export const anchor = createFramework({
   },
   githubExample: {
     name: "Create Account",
-    url: "https://github.com/solana-developers/program-examples/tree/main/basics/create-account/anchor",
+    url: "https://github.com/solana-foundation/program-examples/tree/main/basics/create-account/anchor",
   },
   getIsCurrent: (files) => {
     // Return false if there is a Python file(Seahorse) otherwise this will

--- a/client/src/frameworks/anchor/export.md
+++ b/client/src/frameworks/anchor/export.md
@@ -2,7 +2,7 @@
 
 - Install tools
 
-Instructions on how to install [Anchor](https://github.com/coral-xyz/anchor) can be found [here](https://www.anchor-lang.com/docs/installation).
+Instructions on how to install [Anchor](https://github.com/otter-sec/anchor) can be found [here](https://www.anchor-lang.com/docs/installation).
 
 - Install dependencies
 

--- a/client/src/frameworks/anchor/export.ts
+++ b/client/src/frameworks/anchor/export.ts
@@ -141,9 +141,6 @@ ${programName} = "${PgProgramInfo.pk.toBase58()}"`
     : ""
 }
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "Localnet"
 wallet = "~/.config/solana/id.json"

--- a/client/src/frameworks/native/export.md
+++ b/client/src/frameworks/native/export.md
@@ -2,7 +2,7 @@
 
 - Install tools
 
-Instructions on how to install [Solana](https://github.com/solana-labs/solana) can be found [here](https://docs.solana.com/cli/install-solana-cli-tools).
+Instructions on how to install [Solana](https://github.com/solana-labs/solana) can be found [here](https://solana.com/docs/intro/installation).
 
 - Install dependencies
 

--- a/client/src/frameworks/native/native.ts
+++ b/client/src/frameworks/native/native.ts
@@ -17,8 +17,8 @@ export const native = createFramework({
     // is to make everything that works in a local Node environment work in
     // Playground without any modifications.
     // TODO: Implement `fs` and `os` modules.
-    // url: "https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana/native",
-    url: "https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana/native/program",
+    // url: "https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana/native",
+    url: "https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana/native/program",
   },
   getIsCurrent: (files) => {
     for (const [path, content] of files) {

--- a/client/src/settings/connection/connection.ts
+++ b/client/src/settings/connection/connection.ts
@@ -50,7 +50,7 @@ export const connection = [
       },
       type: "micro lamports",
       placeholder: "9000",
-      tip: "Check out the priority fees [guide](https://solana.com/developers/guides/advanced/how-to-use-priority-fees) for more information.",
+      tip: "Check out the priority fees [guide](https://solana.com/docs/core/fees) for more information.",
     },
   }),
 ];

--- a/client/src/tutorials/__template/template.ts
+++ b/client/src/tutorials/__template/template.ts
@@ -3,7 +3,7 @@ import { createTutorial } from "../create";
 export const template = createTutorial({
   name: "Template tutorial",
   description: "Simple template tutorial description",
-  authors: [{ name: "acheron", link: "https://twitter.com/acheroncrypto" }],
+  authors: [{ name: "acheron", link: "https://x.com/acheroncrypto" }],
   level: "Beginner",
   framework: "Anchor",
   languages: ["Rust", "TypeScript"],

--- a/client/src/tutorials/hello-anchor/hello-anchor.ts
+++ b/client/src/tutorials/hello-anchor/hello-anchor.ts
@@ -3,7 +3,7 @@ import { createTutorial } from "../create";
 export const helloAnchor = createTutorial({
   name: "Hello Anchor",
   description: "Hello world program with Anchor framework.",
-  authors: [{ name: "acheron", link: "https://twitter.com/acheroncrypto" }],
+  authors: [{ name: "acheron", link: "https://x.com/acheroncrypto" }],
   level: "Beginner",
   framework: "Anchor",
   languages: ["Rust", "TypeScript"],

--- a/client/src/tutorials/hello-anchor/pages/1.md
+++ b/client/src/tutorials/hello-anchor/pages/1.md
@@ -1,6 +1,6 @@
 # Hello world program 🌍️
 
-We are going to be writing a [Hello world](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) program with [Anchor](https://anchor-lang.com/).
+We are going to be writing a [Hello world](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) program with [Anchor](https://www.anchor-lang.com/).
 
 Anchor offers a lot of improvements over Native Solana programs in terms of developer friendliness and security of the programs. Let's get started!
 

--- a/client/src/tutorials/hello-seahorse/hello-seahorse.ts
+++ b/client/src/tutorials/hello-seahorse/hello-seahorse.ts
@@ -3,7 +3,7 @@ import { createTutorial } from "../create";
 export const helloSeahorse = createTutorial({
   name: "Hello Seahorse",
   description: "Hello world program with Seahorse framework in Python.",
-  authors: [{ name: "acheron", link: "https://twitter.com/acheroncrypto" }],
+  authors: [{ name: "acheron", link: "https://x.com/acheroncrypto" }],
   level: "Beginner",
   framework: "Seahorse",
   languages: ["Python", "TypeScript"],

--- a/client/src/tutorials/hello-seahorse/pages/1.md
+++ b/client/src/tutorials/hello-seahorse/pages/1.md
@@ -2,7 +2,7 @@
 
 We are going to be writing a [Hello world](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) program with [Seahorse](https://www.seahorse.dev/).
 
-Seahorse allows us to write programs in Python that transpiles into [Anchor](https://anchor-lang.com/) code.
+Seahorse allows us to write programs in Python that transpiles into [Anchor](https://www.anchor-lang.com/) code.
 
 Let's get started!
 

--- a/client/src/tutorials/hello-solana/hello-solana.ts
+++ b/client/src/tutorials/hello-solana/hello-solana.ts
@@ -3,7 +3,7 @@ import { createTutorial } from "../create";
 export const helloSolana = createTutorial({
   name: "Hello Solana",
   description: "Hello world program with Native Solana/Rust.",
-  authors: [{ name: "acheron", link: "https://twitter.com/acheroncrypto" }],
+  authors: [{ name: "acheron", link: "https://x.com/acheroncrypto" }],
   level: "Beginner",
   framework: "Native",
   languages: ["Rust", "TypeScript"],

--- a/client/src/tutorials/hello-solana/pages/1.md
+++ b/client/src/tutorials/hello-solana/pages/1.md
@@ -1,6 +1,6 @@
 # Hello world program 🌍️
 
-We are going to be writing a [Hello world](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) program with [Rust programming language](https://www.rust-lang.org/). You don't need to be an expert in Rust to follow along. Let's get started!
+We are going to be writing a [Hello world](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) program with [Rust programming language](https://rust-lang.org/). You don't need to be an expert in Rust to follow along. Let's get started!
 
 ## Instruction
 

--- a/client/src/utils/github.ts
+++ b/client/src/utils/github.ts
@@ -41,7 +41,7 @@ export class PgGithub {
    * @returns the parsed URL
    */
   static parseUrl(url: string) {
-    // https://github.com/solana-labs/solana-program-library/tree/master/token/program
+    // https://github.com/solana-program/token/tree/main/program
     const regex =
       /(https:\/\/)?(github\.com\/)([\w-]+)\/([\w-]+)(\/)?((tree|blob)\/([\w-.]+))?(\/)?([\w-/.]*)/;
     const res = regex.exec(url);

--- a/client/src/utils/program-interaction/instruction.ts
+++ b/client/src/utils/program-interaction/instruction.ts
@@ -93,7 +93,7 @@ export const fillRandom = (
 const createAccountGenerator = (acc: IdlAccount): InstructionValueGenerator => {
   // Handle `seeds` feature
   // TODO: Re-evaluate this once Anchor package has proper types for PDA seeds
-  // https://github.com/coral-xyz/anchor/issues/2750
+  // https://github.com/otter-sec/anchor/issues/2750
   if (acc.pda) {
     return {
       type: "From seed",

--- a/client/src/views/sidebar/explorer/Component/Modals/ImportGithub.tsx
+++ b/client/src/views/sidebar/explorer/Component/Modals/ImportGithub.tsx
@@ -82,7 +82,7 @@ export const ImportGithub = () => {
 };
 
 const GITHUB_PROGRAM_URL =
-  "https://github.com/solana-developers/program-examples/tree/main/basics/create-account/anchor";
+  "https://github.com/solana-foundation/program-examples/tree/main/basics/create-account/anchor";
 
 const VIEW_URL = PgRouter.getPathUrl(GITHUB_PROGRAM_URL);
 

--- a/vscode/src/commands/create/anchor.ts
+++ b/vscode/src/commands/create/anchor.ts
@@ -156,9 +156,6 @@ skip-lint = false
 [programs.localnet]
 default = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
-[registry]
-url = "https://api.apr.dev"
-
 [provider]
 cluster = "localnet"
 wallet = "${PgWallet.DEFAULT_KEYPAIR_PATH}"

--- a/vscode/src/utils/connection.ts
+++ b/vscode/src/utils/connection.ts
@@ -17,24 +17,18 @@ interface Network {
 enum NetworkName {
   LOCALHOST = "localhost",
   DEVNET = "devnet",
-  DEVNET_GENESYSGO = "devnet-genesysgo",
   DEVNET_ALCHEMY = "devnet-alchemy",
   TESTNET = "testnet",
   MAINNET_BETA = "mainnet-beta",
-  MAINNET_BETA_GENESYSGO = "mainnet-beta-genesysgo",
-  MAINNET_BETA_SERUM = "mainnet-beta-serum",
   CUSTOM = "custom",
 }
 
 enum Endpoint {
   LOCALHOST = "http://localhost:8899",
   DEVNET = "https://api.devnet.solana.com",
-  DEVNET_GENESYSGO = "https://devnet.genesysgo.net/",
   DEVNET_ALCHEMY = "https://solana-devnet.g.alchemy.com/v2/demo",
   TESTNET = "https://api.testnet.solana.com",
   MAINNET_BETA = "https://api.mainnet-beta.solana.com",
-  MAINNET_BETA_GENESYSGO = "https://ssc-dao.genesysgo.net",
-  MAINNET_BETA_SERUM = "https://solana-api.projectserum.com",
 }
 
 export class PgConnection {
@@ -48,10 +42,6 @@ export class PgConnection {
       endpoint: Endpoint.DEVNET,
     },
     {
-      name: NetworkName.DEVNET_GENESYSGO,
-      endpoint: Endpoint.DEVNET_GENESYSGO,
-    },
-    {
       name: NetworkName.DEVNET_ALCHEMY,
       endpoint: Endpoint.DEVNET_ALCHEMY,
     },
@@ -62,14 +52,6 @@ export class PgConnection {
     {
       name: NetworkName.MAINNET_BETA,
       endpoint: Endpoint.MAINNET_BETA,
-    },
-    {
-      name: NetworkName.MAINNET_BETA_GENESYSGO,
-      endpoint: Endpoint.MAINNET_BETA_GENESYSGO,
-    },
-    {
-      name: NetworkName.MAINNET_BETA_SERUM,
-      endpoint: Endpoint.MAINNET_BETA_SERUM,
     },
   ];
 

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -47,7 +47,7 @@ if ! command -v wasm-pack 2>&1 >/dev/null; then
 
     # Install a specific version of `wasm-pack` without default features. See:
     # - https://github.com/RReverser/wasm-bindgen-rayon/issues/9
-    # - https://github.com/rustwasm/wasm-pack/issues/1186#issuecomment-1374814605
+    # - https://github.com/wasm-bindgen/wasm-pack/issues/1186#issuecomment-1374814605
     cargo install wasm-pack@0.10.3 --locked --no-default-features
 fi
 

--- a/wasm/solana-client/src/pubsub.rs
+++ b/wasm/solana-client/src/pubsub.rs
@@ -206,7 +206,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`accountSubscribe`] RPC method.
     ///
-    /// [`accountSubscribe`]: https://docs.solana.com/api/websocket#accountsubscribe
+    /// [`accountSubscribe`]: https://solana.com/docs/rpc/websocket/accountsubscribe
     pub async fn account_subscribe<F>(&self, pubkey: Pubkey, cb: F) -> SubscriptionId
     where
         F: Fn(GetAccountInfoResponse) + Send + 'static,
@@ -230,7 +230,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`accountSubscribe`] RPC method.
     ///
-    /// [`accountSubscribe`]: https://docs.solana.com/api/websocket#accountsubscribe
+    /// [`accountSubscribe`]: https://solana.com/docs/rpc/websocket/accountsubscribe
     pub async fn account_subscribe_with_config<F>(
         &self,
         pubkey: Pubkey,
@@ -260,7 +260,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`blockSubscribe`] RPC method.
     ///
-    /// [`blockSubscribe`]: https://docs.solana.com/api/websocket#blocksubscribe
+    /// [`blockSubscribe`]: https://solana.com/docs/rpc/websocket/blocksubscribe
     pub async fn block_subscribe<F>(
         &self,
         filter: RpcBlockSubscribeFilter,
@@ -283,7 +283,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`logsSubscribe`] RPC method.
     ///
-    /// [`logsSubscribe`]: https://docs.solana.com/api/websocket#logssubscribe
+    /// [`logsSubscribe`]: https://solana.com/docs/rpc/websocket/logssubscribe
     pub async fn logs_subscribe<F>(
         &self,
         filter: RpcTransactionLogsFilter,
@@ -307,7 +307,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`programSubscribe`] RPC method.
     ///
-    /// [`programSubscribe`]: https://docs.solana.com/api/websocket#programsubscribe
+    /// [`programSubscribe`]: https://solana.com/docs/rpc/websocket/programsubscribe
     pub async fn program_subscribe<F>(
         &self,
         pubkey: &Pubkey,
@@ -338,7 +338,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`voteSubscribe`] RPC method.
     ///
-    /// [`voteSubscribe`]: https://docs.solana.com/api/websocket#votesubscribe
+    /// [`voteSubscribe`]: https://solana.com/docs/rpc/websocket/votesubscribe
     pub async fn vote_subscribe<F>(&self, cb: F) -> SubscriptionId
     where
         F: Fn(RpcVote) + Send + 'static,
@@ -358,7 +358,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`signatureSubscribe`] RPC method.
     ///
-    /// [`signatureSubscribe`]: https://docs.solana.com/api/websocket#signaturesubscribe
+    /// [`signatureSubscribe`]: https://solana.com/docs/rpc/websocket/signaturesubscribe
     pub async fn signature_subscribe<F>(
         &self,
         signature: &Signature,
@@ -385,7 +385,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`slotSubscribe`] RPC method.
     ///
-    /// [`slotSubscribe`]: https://docs.solana.com/api/websocket#slotsubscribe
+    /// [`slotSubscribe`]: https://solana.com/docs/rpc/websocket/slotsubscribe
     pub async fn slot_subscribe<F>(&self, cb: F) -> SubscriptionId
     where
         F: Fn(SlotInfo) + Send + 'static,
@@ -406,7 +406,7 @@ impl WasmClient {
     ///
     /// This method corresponds directly to the [`slotUpdatesSubscribe`] RPC method.
     ///
-    /// [`slotUpdatesSubscribe`]: https://docs.solana.com/api/websocket#slotsubscribe
+    /// [`slotUpdatesSubscribe`]: https://solana.com/docs/rpc/websocket/slotsupdatessubscribe
     pub async fn slot_updates_subscribe<F>(&self, cb: F) -> SubscriptionId
     where
         F: Fn(SlotUpdate) + Send + 'static,

--- a/wasm/utils/solana-clap-v3-utils/src/keypair.rs
+++ b/wasm/utils/solana-clap-v3-utils/src/keypair.rs
@@ -648,7 +648,7 @@ pub struct SignerFromPathConfig {
 /// [qs]: https://en.wikipedia.org/wiki/Query_string
 /// [dp]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 /// [URI]: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
-/// ["hardened"]: https://wiki.trezor.io/Hardened_and_non-hardened_derivation
+/// ["hardened"]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 ///
 /// # Examples
 ///

--- a/wasm/utils/solana-clap-v3-utils/src/nonce.rs
+++ b/wasm/utils/solana-clap-v3-utils/src/nonce.rs
@@ -9,7 +9,7 @@ pub const NONCE_ARG: ArgConstant<'static> = ArgConstant {
     help: "Provide the nonce account to use when creating a nonced \n\
            transaction. Nonced transactions are useful when a transaction \n\
            requires a lengthy signing process. Learn more about nonced \n\
-           transactions at https://docs.solana.com/offline-signing/durable-nonce",
+           transactions at https://docs.anza.xyz/cli/examples/durable-nonce",
 };
 
 pub const NONCE_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {

--- a/wasm/utils/solana-cli-config/src/config.rs
+++ b/wasm/utils/solana-cli-config/src/config.rs
@@ -34,7 +34,7 @@ pub struct Config {
     ///
     /// For local testing, the typical value is `http://localhost:8899`.
     ///
-    /// [rpcdocs]: https://docs.solana.com/cluster/rpc-endpoints
+    /// [rpcdocs]: https://solana.com/docs/core/clusters
     pub json_rpc_url: String,
     /// The address to connect to for receiving event notifications.
     ///

--- a/wasm/utils/solana-extra/build.rs
+++ b/wasm/utils/solana-extra/build.rs
@@ -3,7 +3,7 @@ use rustc_version::{version_meta, Channel};
 
 fn main() {
     // Copied and adapted from
-    // https://github.com/Kimundi/rustc-version-rs/blob/1d692a965f4e48a8cb72e82cda953107c0d22f47/README.md#example
+    // https://github.com/djc/rustc-version-rs/blob/1d692a965f4e48a8cb72e82cda953107c0d22f47/README.md#example
     // Licensed under Apache-2.0 + MIT
     match version_meta().unwrap().channel {
         Channel::Nightly | Channel::Dev => {


### PR DESCRIPTION
Refresh URLs across the codebase that have moved or gone stale, and drop a few dead endpoints/config referencing defunct services.

- Solana docs: docs.solana.com -> solana.com/docs and docs.anza.xyz
- Metaplex docs: docs/developers.metaplex.com -> www.metaplex.com/docs
- GitHub repo renames (program-examples, anchor, token, wasm-pack, rustc-version-rs, react)
- Cookbook -> solana.com/developers/cookbook; SolDev -> Developer Courses
- twitter.com -> x.com; anchor-lang.com / rust-lang.org www normalization
- Hardened-derivation reference: Trezor wiki -> BIP-0032

Also remove the defunct api.apr.dev [registry] block from exported Anchor.toml and the dead GenesysGo/Serum RPC endpoints from the VS Code network list.