### PR TITLE
Add ability to scroll past end in test UI

### DIFF
--- a/client/src/views/sidebar/test/Component/Test.tsx
+++ b/client/src/views/sidebar/test/Component/Test.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import BN from "bn.js";
 
 import Account from "./Account";
@@ -138,11 +138,24 @@ const InitialWrapper = styled.div`
 `;
 
 const Wrapper = styled.div`
-  user-select: none;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding-top: 1rem;
+  ${({ theme }) => css`
+    user-select: none;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-top: 1rem;
+    /**
+     * Allow scrolling past the end so the last component can reach the top of
+     * the view, similar to the "scroll beyond last line" behavior in editors.
+     */
+    padding-bottom: calc(
+      100vh -
+        (
+          ${theme.views.sidebar.right.title.height} +
+            ${theme.views.bottom.height}
+        )
+    );
+  `}
 `;
 
 const ProgramNameWrapper = styled.div`


### PR DESCRIPTION
### Problem

The test UI is autogenerated from the IDL and can get long. Expanding instructions/accounts near the bottom forces excessive scrolling, and the last component can't be brought up into comfortable view.

### Change

Add `padding-bottom` to the test panel's wrapper so the view can scroll past the end — the last component can be scrolled to the top, matching the scroll-beyond-last-line behavior of editors like monaco-editor.

Scoped to the test panel wrapper so other sidebar pages are unaffected.

Closes #168