### PR TITLE
Automatically fetch on-chain IDL when a program is deployed

### DIFF
--- a/client/src/effects/fetch-idl/fetch-idl.ts
+++ b/client/src/effects/fetch-idl/fetch-idl.ts
@@ -1,0 +1,41 @@
+import { PgCommon, PgFramework, PgProgramInfo, PgTerminal } from "../../utils";
+
+/**
+ * Automatically fetch the on-chain Anchor IDL of the current program.
+ *
+ * This runs when the program is deployed and there is no IDL available
+ * locally, e.g. when interacting with a pre-deployed program via a custom
+ * program id or an imported keypair. An existing IDL (imported or built) is
+ * never overwritten.
+ */
+export const fetchIdl = () => {
+  return PgCommon.batchChanges(async () => {
+    const programId = PgProgramInfo.pk;
+
+    // Only fetch when the program is deployed and there is no local IDL.
+    if (!programId || PgProgramInfo.idl || !PgProgramInfo.onChain?.deployed) {
+      return;
+    }
+
+    // TODO: Remove once `PgProgramInfo.fetchIdl` is framework-agnostic
+    // (Seahorse programs are Anchor-compatible and also have Anchor IDLs)
+    const framework = await PgFramework.getFromFiles();
+    if (framework?.name !== "Anchor" && framework?.name !== "Seahorse") return;
+
+    try {
+      const result = await PgProgramInfo.fetchIdl(programId);
+      if (!result) return;
+
+      // Bail if the state changed while fetching (the IDL was set or the
+      // program id changed) so newer data is not overwritten.
+      if (PgProgramInfo.idl || !PgProgramInfo.pk?.equals(programId)) return;
+
+      PgProgramInfo.update({ idl: result.idl });
+      PgTerminal.println(PgTerminal.success("Fetched the on-chain IDL."));
+    } catch {
+      // Fetching can fail for various reasons, e.g. the connection not being
+      // ready or the request getting rate-limited. Ignore because this runs
+      // automatically in the background.
+    }
+  }, [PgProgramInfo.onDidChangePk, PgProgramInfo.onDidChangeOnChain]);
+};

--- a/client/src/effects/fetch-idl/index.ts
+++ b/client/src/effects/fetch-idl/index.ts
@@ -1,0 +1,1 @@
+export * from "./fetch-idl";


### PR DESCRIPTION
### Problem

When a user sets a custom program id (e.g. to interact with a pre-deployed program), the playground has no way to obtain the program's Anchor IDL. The IDL is only ever populated from a local build or a manual JSON import, so testing a pre-deployed program requires manually importing its IDL.

### Change

Add an effect that automatically fetches the on-chain IDL when a custom program id is set, reusing the existing `PgProgramInfo.fetchIdl`.

- Limited to custom program ids — a program built in the playground already gets its IDL from the build output.
- Never overwrites an existing IDL (imported or built), and re-checks state after the async fetch so newer data isn't clobbered.
- Runs in the background; fetch failures (connection not ready / no on-chain IDL) are ignored.

This matches the approach suggested in the issue thread (fetch once a custom program id is set).

Closes #93