### PR TITLE
chore: allowlist Vercel client origins on the server; carry over #447 review follow-ups

### DIFF
--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -145,5 +145,12 @@ jobs:
       - name: Check git status
         run: git status --porcelain | wc -l | grep -q -w "0"
 
+      # Unlike the build, `tsc --noEmit` also covers test files.
+      - name: Check types
+        run: yarn test-types
+
+      - name: Run unit tests
+        run: yarn test-unit
+
       - name: Build
         run: yarn build

--- a/client/docs/deploy-client-vercel.md
+++ b/client/docs/deploy-client-vercel.md
@@ -13,16 +13,14 @@ Vercel's native Git integration auto-deploys: `master` → production; any other
 | Root Directory | `client` |
 | Production Branch | `master` |
 | Ignored Build Step | Automatic |
-| Node | `22.x` (project); `^22.20.0` (`package.json` engines) |
 
 ## One-time setup
 
 1. Create the project. Framework: Other. Root Directory: `client`.
 2. Build Machine: Enhanced on Enterprise; default on Pro.
 3. Production Branch: `master`. Ignored Build Step: Automatic.
-4. Node.js Version: `22.x`.
-5. Account Settings → Tokens: team-scoped token, `export VERCEL_TOKEN=...` locally for the Makefile targets.
-6. Link the local checkout (from repo root):
+4. Account Settings → Tokens: team-scoped token, `export VERCEL_TOKEN=...` locally for the Makefile targets.
+5. Link the local checkout (from repo root):
 
    ```sh
    VERCEL_PROJECT_ID=prj_xxx make vercel-bootstrap

--- a/server/app.yaml
+++ b/server/app.yaml
@@ -11,6 +11,8 @@ automatic_scaling:
 env_variables:
   # Each cargo-build-sbf peaks ~3.7GB and ~1 core; sized with resources below for 3 concurrent builds, leaving 1 core for serving.
   PG_BUILD_CONCURRENCY: "3"
+  # Prefix-matched against Origin (no trailing slashes). The `solana-playground-` prefix temporarily admits dynamic Vercel preview URLs and might be dropped later.
+  PG_CLIENT_URLS: "https://beta.solpg.io,https://solana-playground-two.vercel.app,https://solana-playground-,http://localhost"
 
 resources:
   cpu: 4


### PR DESCRIPTION
**Context.** The GAE server's CORS allowlist (`PG_CLIENT_URLS`, prefix-matched) still runs on its compiled-in default, which predates the Vercel client deployment from #447. Bundled: the remaining CI/doc follow-ups from the #447 post-merge review.

**Problem.** CORS rejects every request from the Vercel client — production (`solana-playground-two.vercel.app`) and preview (`solana-playground-<hash>-solana-foundation.vercel.app`) alike. From the review: client tests are not run in CI, and the deploy doc pins a Node version that duplicates `package.json` `engines`.

**Why to solve.** The deployed Vercel client cannot build or deploy programs against the foundation-hosted server; the rest closes out the review asks left open at merge.

Notes: the `solana-playground-` prefix entry admitting dynamic preview hostnames is temporary and may be dropped later for a stable alias domain. Verified against a locally-run server — real deployment URLs pass preflight, unrelated origins are blocked.
