### PR TITLE
fix(server): restore owner write bit on programs dir stripped by Cloud Build staging

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -63,6 +63,8 @@ WORKDIR /home/${USER}
 
 # Copy programs dir and build the default program
 COPY --chown=${USER}:${USER} programs programs
+# Cloud Build's legacy builder strips the owner write bit from context files; the server rewrites programs/<id>/Cargo.toml at runtime
+RUN chmod -R u+w programs
 RUN cargo-build-sbf --manifest-path programs/Cargo.toml
 
 # Start server


### PR DESCRIPTION
**Context.** `gcloud app deploy` staging strips the owner write bit from context files, so `programs/Cargo.toml` and `Cargo.lock` arrive in the GAE server image as `555` instead of the checkout's `644`.

**Problem.** Every `/build` on the deployed server returns `500 — Permission denied (os error 13)`: the per-build manifest rewrite (`fs::write` on `programs/<id>/Cargo.toml`) fails on the read-only file.

**Why to solve.** The deployed server cannot build any program.

**Solution.** `RUN chmod -R u+w programs` after the `COPY`. Owner-only, group/other untouched — security-neutral, since the server already runs as the owning uid.
