### PR TITLE
docs: fix nonexistent Docker Compose profile in client README

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -26,10 +26,10 @@ docker compose -f ../compose.yaml --profile dev up --build
 
 ### Standalone (client only, without the server)
 
-To run only the client without building or depending on the server, use the `standalone` profile. The client will use the production API (`https://api.solpg.io`) instead of a local server:
+To run only the client without building or depending on the server, use the `client-standalone` profile. The client will use the production API (`https://api.solpg.io`) instead of a local server:
 
 ```sh
-docker compose -f ../compose.yaml --profile standalone up --build
+docker compose -f ../compose.yaml --profile client-standalone up --build
 ```
 
 See the [root README](../README.md#run-with-docker) for more options.


### PR DESCRIPTION
`client/README.md` documents running the standalone client with:

```sh
docker compose -f ../compose.yaml --profile standalone up --build
```

But `compose.yaml` defines no profile named `standalone` — the profiles are `dev`, `prod`, and `client-standalone`. `--profile standalone` matches zero services, so the command starts nothing. The correct profile is **`client-standalone`** (`compose.yaml`), which the root `README.md` already uses (`docker compose up client-standalone`). Fixed the profile name in both the prose and the command in `client/README.md`.