### PR TITLE
Display Rust Analyzer status in the bottom bar

### DIFF
--- a/client/src/components/Editor/Monaco/languages/rust/init.ts
+++ b/client/src/components/Editor/Monaco/languages/rust/init.ts
@@ -1,3 +1,9 @@
 import { initRustAnalyzer } from "./rust-analyzer";
+import { PgEditor } from "../../../../../utils";
 
-export const init = () => initRustAnalyzer();
+export const init = () =>
+  initRustAnalyzer().catch((e) => {
+    // Otherwise the last status stays in the bottom bar forever
+    PgEditor.setRustAnalyzerStatus(null);
+    throw e;
+  });

--- a/client/src/components/Editor/Monaco/languages/rust/rust-analyzer/rust-analyzer.ts
+++ b/client/src/components/Editor/Monaco/languages/rust/rust-analyzer/rust-analyzer.ts
@@ -7,6 +7,7 @@ import {
   AsyncMethods,
   Disposable,
   PgCommon,
+  PgEditor,
   PgExplorer,
 } from "../../../../../../utils";
 
@@ -41,9 +42,11 @@ export const initRustAnalyzer = async (): Promise<Disposable> => {
   // unknown reasons. Retry until success in order to mitigate this problem.
   // The try interval should take into account the initial download time of the
   // Rust Analyzer WASM files(~9MB) on slower connections.
+  PgEditor.setRustAnalyzerStatus("Starting");
   state = await PgCommon.tryUntilSuccess(createWorker, 10000);
 
   // Initialize and load the default crates
+  PgEditor.setRustAnalyzerStatus("Loading default crates");
   await state.loadDefaultCrates(
     ...(await Promise.all([
       PgCommon.fetchText("/crates/core.rs"),
@@ -52,6 +55,7 @@ export const initRustAnalyzer = async (): Promise<Disposable> => {
     ]))
   );
 
+  PgEditor.setRustAnalyzerStatus("Loading workspace");
   const { dispose: disposeUpdateCurrentCrate } = await PgCommon.executeInitial(
     (cb) => {
       // Both `onDidInit` and `onDidSwitchWorkspace` is required to catch all
@@ -99,6 +103,9 @@ export const initRustAnalyzer = async (): Promise<Disposable> => {
   // Register providers at the end in order to avoid out of bound errors due to
   // a possible mismatch between the LSP and the client files before initialization
   const { dispose: disposeProviders } = registerProviders();
+
+  // Initialization is complete
+  PgEditor.setRustAnalyzerStatus(null);
 
   return {
     dispose: () => {

--- a/client/src/utils/editor.ts
+++ b/client/src/utils/editor.ts
@@ -1,14 +1,63 @@
 import { PgCommon } from "./common";
+import type { Disposable } from "./types";
+
+/**
+ * Rust Analyzer initialization status.
+ *
+ * `null` means Rust Analyzer is not initializing, either because it hasn't
+ * started yet or because it has already finished.
+ */
+export type RustAnalyzerStatus =
+  | "Starting"
+  | "Loading default crates"
+  | "Loading workspace"
+  | null;
 
 export class PgEditor {
   /** All editor event names */
   static readonly events = {
     FOCUS: "editorfocus",
     FORMAT: "editorformat",
+    RUST_ANALYZER_STATUS_SET: "editorrustanalyzerstatusset",
   };
 
   /** Focus the editor. */
   static focus() {
     PgCommon.createAndDispatchCustomEvent(PgEditor.events.FOCUS);
   }
+
+  /** Current Rust Analyzer initialization status */
+  static get rustAnalyzerStatus() {
+    return PgEditor._rustAnalyzerStatus;
+  }
+
+  /**
+   * Set the current Rust Analyzer initialization status.
+   *
+   * @param status status to set, `null` when initialization is complete
+   */
+  static setRustAnalyzerStatus(status: RustAnalyzerStatus) {
+    PgEditor._rustAnalyzerStatus = status;
+    PgCommon.createAndDispatchCustomEvent(
+      PgEditor.events.RUST_ANALYZER_STATUS_SET,
+      status
+    );
+  }
+
+  /**
+   * Run the given callback when Rust Analyzer's initialization status changes.
+   *
+   * @param cb callback to run
+   * @returns a dispose function to clear the event
+   */
+  static onDidChangeRustAnalyzerStatus(
+    cb: (status: RustAnalyzerStatus) => unknown
+  ): Disposable {
+    return PgCommon.onDidChange(PgEditor.events.RUST_ANALYZER_STATUS_SET, cb, {
+      value: PgEditor.rustAnalyzerStatus,
+    });
+  }
+
+  /** Internal Rust Analyzer initialization status */
+  private static _rustAnalyzerStatus: RustAnalyzerStatus = null;
 }

--- a/client/src/views/bottom/RustAnalyzer/RustAnalyzer.tsx
+++ b/client/src/views/bottom/RustAnalyzer/RustAnalyzer.tsx
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+import Tooltip from "../../../components/Tooltip";
+import { useRenderOnChange } from "../../../hooks";
+import { PgEditor } from "../../../utils";
+
+export const RustAnalyzer = () => {
+  const status = useRenderOnChange(PgEditor.onDidChangeRustAnalyzerStatus);
+
+  // Only show while Rust Analyzer is initializing
+  if (!status) return null;
+
+  return (
+    <Tooltip element="Rust Analyzer is getting initialized">
+      <StatusText>{`Rust Analyzer: ${status}`}</StatusText>
+    </Tooltip>
+  );
+};
+
+const StatusText = styled.span``;

--- a/client/src/views/bottom/RustAnalyzer/index.ts
+++ b/client/src/views/bottom/RustAnalyzer/index.ts
@@ -1,0 +1,1 @@
+export { RustAnalyzer } from "./RustAnalyzer";

--- a/client/src/views/bottom/bottom.ts
+++ b/client/src/views/bottom/bottom.ts
@@ -1,7 +1,8 @@
 import { Address } from "./Address";
 import { Balance } from "./Balance";
 import { Cluster } from "./Cluster";
+import { RustAnalyzer } from "./RustAnalyzer";
 import { Wallet } from "./Wallet";
 
 /** All bottom components in order */
-export const BOTTOM = [Wallet, Cluster, Address, Balance];
+export const BOTTOM = [Wallet, Cluster, Address, Balance, RustAnalyzer];


### PR DESCRIPTION
### Problem

There is no indication of Rust Analyzer getting initialized. The loading state can only be seen by hovering the document, which isn't obvious.

Closes #182.

### Change

Track the initialization status in `PgEditor` and add a bottom bar section that displays the current step while Rust Analyzer is initializing.

The status is set at the steps that `initRustAnalyzer` already documents:

1. `Starting` — creating the worker thread
2. `Loading default crates`
3. `Loading workspace`

and cleared once initialization completes. `PgEditor` uses the same custom event approach that's already in the class, with `initialRun` so the component gets the current status even if it mounts mid-initialization.

`init` also clears the status if `initRustAnalyzer` rejects, as otherwise the last status would stay in the bottom bar forever.

### Notes

A couple of decisions that are easy to change if you'd prefer otherwise:

- The section is hidden once initialization completes rather than showing something like `Ready` permanently, since the bottom bar space is shared. Happy to keep it visible instead.
- It's placed last in `BOTTOM`, after `Balance`.

Verified with `tsc --noEmit` and `yarn check-format`.