### PR TITLE
Fix enum variant case conversion not matching Anchor

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "@solana/wallet-adapter-react": "0.15.39",
     "@solana/web3.js": "*",
     "assert": "^2.0.0",
+    "camelcase": "^6.3.0",
     "crypto-browserify": "^3.12.0",
     "jszip": "^3.10.1",
     "mocha": "^10.0.0",

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -1,3 +1,5 @@
+import camelcase from "camelcase";
+
 import type {
   AllPartial,
   Disposable,
@@ -794,13 +796,18 @@ export class PgCommon {
   }
 
   /**
+   * Convert the given string to camelCase.
+   *
+   * NOTE: This uses the same implementation as Anchor(`camelcase` package) in
+   * order to derive the same names for IDL items such as enum variants and
+   * accounts. Rust identifiers are not always PascalCase, e.g. `ADD` or
+   * `ADD_ITEM` are valid enum variants and Anchor converts them to `add` and
+   * `addItem` respectively.
+   *
    * @returns camelCase converted version of the string input
    */
   static toCamelCase(str: string) {
-    return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, (match, index) => {
-      if (+match === 0) return ""; // or if (/\s+/.test(match)) for white spaces
-      return index === 0 ? match.toLowerCase() : match.toUpperCase();
-    });
+    return camelcase(str);
   }
 
   /**


### PR DESCRIPTION
### Problem

`PgCommon.toCamelCase` assumes PascalCase input, so Rust identifiers that aren't PascalCase get converted differently than Anchor converts them:

| input | playground | Anchor |
| --- | --- | --- |
| `Add` | `add` | `add` |
| `AddItem` | `addItem` | `addItem` |
| `ADD` | `aDD` | `add` |
| `ADD_ITEM` | `aDD_ITEM` | `addItem` |
| `add_item` | `add_item` | `addItem` |
| `NFTMint` | `nFTMint` | `nftMint` |

Enum variants end up in `program.methods` in the test UI:

https://github.com/solana-playground/solana-playground/blob/849670c/client/src/utils/program-interaction/program-interaction.ts#L84

and Anchor builds its enum layout with `camelcase(variant.name)`, so a variant like `ADD` produces the key `aDD` while Anchor expects `add`. The variant is listed in the dropdown but can't be resolved when the instruction is sent, which is the error in #191. The dropdown label is wrong for the same reason (`aDD` instead of `add`).

This isn't specific to enums — account names go through the same conversion in `getAccount`, so an account like `NFTMint` has the same problem.

### Change

Use the same `camelcase` package Anchor uses so both sides derive identical names.

`camelcase` is already in the dependency tree as an Anchor dependency, and `^6.3.0` resolves to the entry that's already in the lockfile, so `yarn.lock` is unchanged and nothing new is added to the bundle.

Only conversions that were already diverging from Anchor change. PascalCase input is unaffected, and so is every playground-internal caller (wallet names like `Playground Wallet` -> `playgroundWallet`, cache keys).

Closes #191.

### Notes

- Unit enum variants are still displayed in camelCase, so `ADD` now shows as `add` rather than `ADD`. That matches how `Add` has always been displayed. Happy to show the raw Rust name instead if you'd prefer that.
- Verified with `tsc --noEmit` and `yarn check-format`.