### PR TITLE
Fix f64 serialization to use writeDoubleLE

### DIFF
--- a/client/src/utils/program-interaction/idl-types.ts
+++ b/client/src/utils/program-interaction/idl-types.ts
@@ -551,7 +551,7 @@ const f64 = createIdlType({
   },
   toBuffer: (value) => {
     const buf = Buffer.alloc(8);
-    buf.writeFloatLE(value);
+    buf.writeDoubleLE(value);
     return buf;
   },
   generateRandom: () => Math.random().toString(),


### PR DESCRIPTION
## What

`f64` IDL values are serialized with `Buffer.writeFloatLE`, which writes a 32-bit float into the 8-byte buffer, so the value on the wire is wrong.

## Why

```ts
toBuffer: (value) => {
  const buf = Buffer.alloc(8);
  buf.writeFloatLE(value); // writes 4 bytes into an 8-byte f64 buffer
  return buf;
},
```

The buffer is 8 bytes, so an `f64` (IEEE-754 double) is intended, but `writeFloatLE` only fills the first 4 bytes with a single precision float and leaves bytes 4 to 7 as zero. Nothing throws because the length is already correct. The neighboring `f32` uses `writeFloatLE` on a 4-byte buffer, which is correct, so this looks like a copy paste slip.

Read back as a double, the bytes are meaningless:

- `1.0` becomes `[0, 0, 128, 63, 0, 0, 0, 0]`, which decodes to `5.263544247e-315`
- `3.14` becomes `[195, 245, 72, 64, 0, 0, 0, 0]`

`toBuffer` is used for PDA seed derivation in `generator.ts` (`toBuffer(parse(value))` is passed to `findProgramAddressSync`), so an `f64` seed derives the wrong program address.

## Change

Use `writeDoubleLE` so the full 8-byte double is written. With the fix, `1.0` serializes to `[0, 0, 0, 0, 0, 0, 240, 63]` and reads back as `1.0`.
