### PR TITLE
Fix signed IDL integer serialization to use two's complement

### DIFF
--- a/client/src/utils/program-interaction/idl-types.ts
+++ b/client/src/utils/program-interaction/idl-types.ts
@@ -495,7 +495,7 @@ const i16 = createIdlType({
     assertInt(value, 2);
     return parseInt(value);
   },
-  toBuffer: (value) => new BN(value).toArrayLike(Buffer, "le", 2),
+  toBuffer: (value) => new BN(value).toTwos(16).toArrayLike(Buffer, "le", 2),
   generateRandom: () => generateRandomInt(2),
 });
 
@@ -505,7 +505,7 @@ const i32 = createIdlType({
     assertInt(value, 4);
     return parseInt(value);
   },
-  toBuffer: (value) => new BN(value).toArrayLike(Buffer, "le", 4),
+  toBuffer: (value) => new BN(value).toTwos(32).toArrayLike(Buffer, "le", 4),
   generateRandom: () => generateRandomInt(4),
 });
 
@@ -515,7 +515,7 @@ const i64 = createIdlType({
     assertInt(value, 8);
     return new BN(value);
   },
-  toBuffer: (value) => value.toArrayLike(Buffer, "le", 8),
+  toBuffer: (value) => value.toTwos(64).toArrayLike(Buffer, "le", 8),
   generateRandom: () => generateRandomInt(8),
 });
 
@@ -525,7 +525,7 @@ const i128 = createIdlType({
     assertInt(value, 16);
     return new BN(value);
   },
-  toBuffer: (value) => value.toArrayLike(Buffer, "le", 16),
+  toBuffer: (value) => value.toTwos(128).toArrayLike(Buffer, "le", 16),
   generateRandom: () => generateRandomInt(16),
 });
 


### PR DESCRIPTION
## What

`i16`, `i32`, `i64` and `i128` IDL values serialize negative numbers as sign magnitude instead of two's complement, so a negative value reaches the program as its positive counterpart.

## Why

```ts
toBuffer: (value) => new BN(value).toArrayLike(Buffer, "le", 4), // i32
```

`BN.toArrayLike` encodes the magnitude little endian and drops the sign, so `-1` produces `01 00 00 00` instead of `ff ff ff ff`. Borsh and anchor decode little endian two's complement, so on chain the field reads back as `+1`. The buffer for `-1` is byte identical to the buffer for `+1`.

Concrete for `i32`:

- `-1` produces `01 00 00 00`, decodes to `+1`, should be `ff ff ff ff`
- `-1000` produces `e8 03 00 00`, decodes to `+1000`, should be `18 fc ff ff`

`assertInt` accepts negatives down to `-(2 ** (bits - 1))`, so these values are valid input and reach `toBuffer`. The neighboring `i8` uses `Buffer.from([value])`, which wraps `-1` to `0xff` correctly, so the intended encoding is two's complement and the multi byte paths look like a copy paste slip. `toBuffer` is also used for PDA seed derivation in `generator.ts`, so a negative signed seed derives the wrong program address.

## Change

Apply `.toTwos(bits)` before `toArrayLike` for `i16`, `i32`, `i64` and `i128`. With the fix, `-1` serializes to all `ff` bytes and reads back as `-1`, matching Rust `to_le_bytes`. Unsigned types are unaffected.
